### PR TITLE
Editor env var; Editor arguments

### DIFF
--- a/cmd/utils/editor.go
+++ b/cmd/utils/editor.go
@@ -49,13 +49,8 @@ func EditYamlInEditor(objectName string, content string) (string, error) {
 	}
 
 	editor := config.GetEditor()
-	editor_path, err := exec.LookPath(editor)
 
-	if err != nil {
-		return "", fmt.Errorf("Failed to open editor '%s'", err)
-	}
-
-	cmd := exec.Command(editor_path, tmpfile.Name())
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("%s %s", editor, tmpfile.Name()))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	err = cmd.Start()

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/spf13/viper"
 )
@@ -52,11 +53,17 @@ func GetEditor() string {
 	if flag.Lookup("test.v") == nil {
 		editor := viper.GetString("editor")
 
-		if editor == "" {
-			return "vim"
-		} else {
+		if editor != "" {
 			return editor
 		}
+
+		editor = os.Getenv("EDITOR")
+
+		if editor != "" {
+			return editor
+		}
+
+		return "vim"
 	} else {
 		return "true" // Bash 'true' command, do nothing in tests
 	}


### PR DESCRIPTION
Two changes in this PR:

1. The order of editor lookup: (1) try from config, (2) try from EDITOR env var, (3) use vim
2. Editor can now have additional flags, example: `subt --something`.

Supporting flags in editor command wasn't straghtforward, but I found a solution in https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/editor/editor.go#L70.

fixes https://github.com/semaphoreci/cli/issues/130
fixes https://github.com/semaphoreci/cli/issues/132