### PR TITLE
Adjust correct version variable with goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
 - env:
   - CGO_ENABLED=0
   ldflags:
-    - -s -w -X main.VERSION={{.Tag}}
+    - -s -w -X cmd.VERSION={{.Tag}}
   goos:
     - linux
     - darwin


### PR DESCRIPTION
The [previous attempt](https://github.com/semaphoreci/cli/pull/147) doesn't work, example with edge release:
![Screenshot from 2019-04-25 11-58-00](https://user-images.githubusercontent.com/21684087/56727734-8e5d4580-6751-11e9-8bac-e30bb6be0b4f.png)

My guess is bc we are trying to change the `VERSION` in the main package, as we do in agent. However, here the `VERION` lives in the cmd package, in a separate file: https://github.com/semaphoreci/cli/blob/master/cmd/version.go#L9

Not sure if goreleaser can access other packages than main, though. :thinking: 