### PR TITLE
Establish SSH connection with IdentitiesOnly flag set to "yes"

### DIFF
--- a/cmd/ssh/connection.go
+++ b/cmd/ssh/connection.go
@@ -147,10 +147,12 @@ func (c *Connection) sshCommand(directive string, interactive bool) (*exec.Cmd, 
 
 	noStrictFlag := "-oStrictHostKeyChecking=no"
 	timeoutFlag := "-oConnectTimeout=5"
+	identitiesOnlyFlag := "-oIdentitiesOnly=yes"
 	userAndIp := fmt.Sprintf("%s@%s", c.Username, c.IP)
 
 	cmd := exec.Command(
 		path,
+		identitiesOnlyFlag,
 		interactiveFlag,
 		sshKeyFlag,
 		portFlag,


### PR DESCRIPTION
A customer reported that he is not able to start a debug session, and that he sees the following error message in his output:

```
$ sem attach <job-id>                                                                                                                                                                                       
Warning: Permanently added '[<ip>]:<port>' (RSA) to the list of known hosts.
Received disconnect from <ip> port <port>:2: Too many authentication failures
Disconnected from <ip> port <port>
```

**Root Cause of Too many authentication failures**

The most common cause of this issue is if you have multiple keys set up on your machine, and you breach the `MaxAuthTries` configuration on the server. The default value of this is set to `6`, in other words, if you have more than `6` keys that are checked in a sequence the server will reject your connection.

**How to reproduce this issue**

First, create 6 keys on your machine and add them to your ssh agent:

``` bash
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_1
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_2
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_3
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_4
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_5
ssh-keygen -b 2048 -t rsa -N "" -f ~/.ssh/id_rsa_6

eval `ssh-agent`
ssh-add ~/.ssh/id_rsa_1
ssh-add ~/.ssh/id_rsa_2
ssh-add ~/.ssh/id_rsa_3
ssh-add ~/.ssh/id_rsa_4
ssh-add ~/.ssh/id_rsa_5
ssh-add ~/.ssh/id_rsa_6
```

Then, create your actual key somewhere else, and add it to the authorized keys:

``` bash
ssh-keygen -b 2048 -t rsa -N "" -f /tmp/real-key
echo /tmp/real-key.pub >> ~/.ssh/authorized_keys
```

Now, if you try to connect without the IdentitiesOnly flag set to `yes`:

```
ssh -i /tmp/real-key localhost
```

You will rejected. The SSH agent will offer the keys in the following sequence:

- `~/.ssh/id_rsa_1`
- `~/.ssh/id_rsa_2`
- `~/.ssh/id_rsa_3`
- `~/.ssh/id_rsa_4`
- `~/.ssh/id_rsa_5`
- `~/.ssh/id_rsa_6`
- `/tmp/real-key` <-- notice that the key that you provided is the last

**The fix introduced in this Pull Request**

This PR introduces an additional flag to the SSH connection when started the debug session:

```
-o IdentitiesOnly=yes
```

This forces the client to use only the key provided with the `-i /tmp/real-key` flag.