### PR TITLE
Wait for user commands to start

### DIFF
--- a/cmd/ssh/connection.go
+++ b/cmd/ssh/connection.go
@@ -84,13 +84,13 @@ func (c *Connection) WaitUntilReady(attempts int, callback func()) error {
 }
 
 func (c *Connection) IsReady() (bool, error) {
-	cmd, err := c.sshCommand("echo 'success'", false)
+	cmd, err := c.sshCommand("cat /tmp/sempahore-user-commands-have-started", false)
 	log.Printf("SSH connection: Running %+v", cmd)
 
 	output, err := cmd.CombinedOutput()
 	log.Printf("SSH connection: Output %s", output)
 
-	if err == nil && strings.Contains(string(output), "success") {
+	if err == nil && strings.Contains(string(output), "yes") {
 		return true, nil
 	} else {
 		outputOneLine := string(output)

--- a/cmd/ssh/connection.go
+++ b/cmd/ssh/connection.go
@@ -84,7 +84,7 @@ func (c *Connection) WaitUntilReady(attempts int, callback func()) error {
 }
 
 func (c *Connection) IsReady() (bool, error) {
-	cmd, err := c.sshCommand("cat /tmp/sempahore-user-commands-have-started", false)
+	cmd, err := c.sshCommand("bash /tmp/ssh_jump_point cat /tmp/sempahore-user-commands-have-started", false)
 	log.Printf("SSH connection: Running %+v", cmd)
 
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
A race condition can occur when we are starting an SSH session. We can jump into the machine _before_ the toolbox commands have completed.

Now, that the backend is creating a marker for us, we can use that marker to check if it is safe to jump into the machine.