### PR TITLE
Fix version when building with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	docker-compose run --rm cli gotestsum --format short-verbose --junitfile results.xml --packages="./..." -- -p 1
 
 build:
-	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w -X cmd.VERSION=$(shell git describe --tags --abbrev=0)" -o sem
+	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w -X main.version=$(shell git describe --tags --abbrev=0)" -o sem
 	tar -czvf /tmp/sem.tar.gz sem
 
 # Automation of CLI tagging.


### PR DESCRIPTION
When building with `make build` the `sem` binary isn't able to report the version:
```
make build && ./sem version
env GOOS= GOARCH= go build -ldflags "-s -w -X cmd.VERSION=v0.28.3" -o sem
tar -czvf /tmp/sem.tar.gz sem
sem
dev, commit none, built at unknown
```

After this fix it is:
```
make build && ./sem version
env GOOS= GOARCH= go build -ldflags "-s -w -X main.version=v0.28.3" -o sem
tar -czvf /tmp/sem.tar.gz sem
sem
v0.28.3, commit none, built at unknown
```