### PR TITLE
feat: self hosted debug sessions

### DIFF
--- a/api/models/job_v1_alpha.go
+++ b/api/models/job_v1_alpha.go
@@ -3,8 +3,8 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
+	"github.com/semaphoreci/cli/cmd/jobs"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -144,7 +144,7 @@ func (j *JobV1Alpha) ToYaml() ([]byte, error) {
 }
 
 func (j *JobV1Alpha) IsSelfHosted() bool {
-	return strings.HasPrefix(j.Spec.Agent.Machine.Type, "s1-")
+	return jobs.IsSelfHosted(j.Spec.Agent.Machine.Type)
 }
 
 func (j *JobV1Alpha) AgentName() string {

--- a/api/models/job_v1_alpha.go
+++ b/api/models/job_v1_alpha.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -140,4 +141,12 @@ func (j *JobV1Alpha) ToJson() ([]byte, error) {
 
 func (j *JobV1Alpha) ToYaml() ([]byte, error) {
 	return yaml.Marshal(j)
+}
+
+func (j *JobV1Alpha) IsSelfHosted() bool {
+	return strings.HasPrefix(j.Spec.Agent.Machine.Type, "s1-")
+}
+
+func (j *JobV1Alpha) AgentName() string {
+	return j.Status.Agent.Name
 }

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -34,7 +34,20 @@ var attachCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Get SSH key for job
+		/*
+		 * If we want to attach to a machine where a self-hosted job is running, no SSH key will be available.
+		 * We just give the agent name back to the user and return.
+		 */
+		if job.IsSelfHosted() {
+			fmt.Printf("* Job '%s' is running in the self-hosted agent named '%s'.\n", id, job.AgentName())
+			fmt.Printf("* Once you access the machine where that agent is running, make sure you are logged in as the same user the Semaphore agent is using.\n")
+			fmt.Printf("* You can source the '/tmp/.env-*' file where the agent keeps all the environment variables exposed to the job.\n")
+			return
+		}
+
+		/*
+		 * If this is for a cloud job, we go for the SSH key.
+		 */
 		sshKey, err := c.GetJobDebugSSHKey(job.Metadata.Id)
 		utils.Check(err)
 

--- a/cmd/debug_project.go
+++ b/cmd/debug_project.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	client "github.com/semaphoreci/cli/api/client"
 	models "github.com/semaphoreci/cli/api/models"
+	"github.com/semaphoreci/cli/cmd/jobs"
 	"github.com/semaphoreci/cli/cmd/ssh"
 	"github.com/semaphoreci/cli/cmd/utils"
 	"github.com/spf13/cobra"
@@ -37,6 +39,11 @@ func NewDebugProjectCmd() *cobra.Command {
 func RunDebugProjectCmd(cmd *cobra.Command, args []string) {
 	machineType, err := cmd.Flags().GetString("machine-type")
 	utils.Check(err)
+
+	if jobs.IsSelfHosted(machineType) {
+		fmt.Printf("Error: self-hosted agent type '%s' can't be used to debug a project. Only cloud agent types are allowed.\n", machineType)
+		os.Exit(1)
+	}
 
 	duration, err := cmd.Flags().GetDuration("duration")
 

--- a/cmd/jobs/states.go
+++ b/cmd/jobs/states.go
@@ -1,1 +1,7 @@
 package jobs
+
+import "strings"
+
+func IsSelfHosted(machineType string) bool {
+	return strings.HasPrefix(machineType, "s1-")
+}

--- a/cmd/ssh/session.go
+++ b/cmd/ssh/session.go
@@ -2,6 +2,8 @@ package ssh
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
 	"time"
 
 	client "github.com/semaphoreci/cli/api/client"
@@ -53,7 +55,22 @@ func StartDebugSession(job *models.JobV1Alpha, message string) error {
 		return err
 	}
 
-	// Get SSH key for job
+	/*
+	 * If this is a debug session for a self-hosted job, an SSH key will not be available.
+	 * The only thing we need to do here is return the self-hosted agent name to the user and hang until the users stops it.
+	 */
+	if job.IsSelfHosted() {
+		fmt.Println(selfHostedSessionMessage(job.AgentName()))
+		fmt.Println("Once you are done with the debug session, stop this command and the debug session will be stopped.")
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		return nil
+	}
+
+	/*
+	 * If this is for a cloud debug session, we grab the SSH key and SSH into the proper machine.
+	 */
 	sshKey, err := c.GetJobDebugSSHKey(job.Metadata.Id)
 	if err != nil {
 		fmt.Printf("\n[ERROR] %s\n", err)
@@ -113,4 +130,17 @@ func waitUntilJobIsRunning(job *models.JobV1Alpha, callback func()) error {
 		// do some processing between ticks
 		callback()
 	}
+}
+
+func selfHostedSessionMessage(agentName string) string {
+	return fmt.Sprintf(`
+Semaphore CI Self-Hosted Debug Session.
+
+  - The debug session you created is running in the self-hosted agent named '%s'.
+  - Once you access the machine where that agent is running, make sure you are logged in as the same user the Semaphore agent is using.
+  - Source the '/tmp/.env-*' file where the agent keeps all the environment variables exposed to the job.
+  - Checkout your code with `+"`checkout`"+`.
+
+Documentation: https://docs.semaphoreci.com/essentials/debugging-with-ssh-access/.
+`, agentName)
 }


### PR DESCRIPTION
This changes the behavior of three commands:
- _sem debug job_: currently, the API does not allow debug sessions to be created for self-hosted jobs. However, that restriction will be removed, and debug sessions for self-hosted jobs will be handled here as well. The only difference between a debug session for a self-hosted, and a cloud job is that self-hosted jobs don't have SSH keys available, so the CLI will not SSH into the self-hosted agent machine after the debug job is created. Instead, we will just display the self-hosted agent name to the user and wait until the user wants to end the session.
- _sem debug project_: using a self-hosted agent type for the `--machine-type` parameter for this command will not be possible.
- _sem attach_: just display the self-hosted agent name to the user and return.