### PR TITLE
feat: add integration-type argument on sem init

### DIFF
--- a/api/models/project_v1_alpha.go
+++ b/api/models/project_v1_alpha.go
@@ -24,13 +24,13 @@ type Status struct {
 }
 
 type PipelineFile struct {
-	Path string `json:"path"`
+	Path  string `json:"path"`
 	Level string `json:"level"`
 }
 
 type Whitelist struct {
 	Branches []string `json:"branches,omitempty"`
-	Tags []string `json:"tags,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
 }
 
 type ProjectV1Alpha struct {
@@ -51,11 +51,12 @@ type ProjectV1Alpha struct {
 			PipelineFile       string             `json:"pipeline_file" yaml:"pipeline_file"`
 			Status             *Status            `json:"status,omitempty" yaml:"status"`
 			Whitelist          Whitelist          `json:"whitelist" yaml:"whitelist"`
+			IntegrationType    string             `json:"integration_type" yaml:"integration_type"`
 		} `json:"repository,omitempty"`
-		Schedulers []Scheduler `json:"schedulers,omitempty" yaml:"schedulers,omitempty"`
-		CustomPermissions *bool `json:"custom_permissions,omitempty" yaml:"custom_permissions,omitempty"`
-		DebugPermissions []string `json:"debug_permissions,omitempty" yaml:"debug_permissions,omitempty"`
-		AttachPermissions []string `json:"attach_permissions,omitempty" yaml:"attach_permissions,omitempty"`
+		Schedulers        []Scheduler `json:"schedulers,omitempty" yaml:"schedulers,omitempty"`
+		CustomPermissions *bool       `json:"custom_permissions,omitempty" yaml:"custom_permissions,omitempty"`
+		DebugPermissions  []string    `json:"debug_permissions,omitempty" yaml:"debug_permissions,omitempty"`
+		AttachPermissions []string    `json:"attach_permissions,omitempty" yaml:"attach_permissions,omitempty"`
 	} `json:"spec,omitempty"`
 }
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -144,6 +144,7 @@ spec:
   visibility: public
   repository:
     url: "git@github.com:/semaphoreci/cli.git"
+    integration_type: github_token
 `
 
 	yaml_file_path := "/tmp/project.yaml"
@@ -164,7 +165,7 @@ spec:
 	RootCmd.SetArgs([]string{"apply", "-f", yaml_file_path})
 	RootCmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"Test","id":"a13949b7-b2f6-4286-8f26-3962d7e97828"},"spec":{"visibility":"public","repository":{"url":"git@github.com:/semaphoreci/cli.git","forked_pull_requests":{},"pipeline_file":"","whitelist":{}}}}`
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"Test","id":"a13949b7-b2f6-4286-8f26-3962d7e97828"},"spec":{"visibility":"public","repository":{"url":"git@github.com:/semaphoreci/cli.git","forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_token"}}}`
 
 	if received != expected {
 		t.Errorf("Expected the API to receive PATCH project with: %s, got: %s", expected, received)

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -24,6 +24,7 @@ spec:
   visibility: public
   repository:
     url: "git@github.com:/semaphoreci/cli.git"
+    integration_type: github_token
 `
 
 	yaml_file_path := "/tmp/project.yaml"
@@ -45,7 +46,7 @@ spec:
 	RootCmd.SetArgs([]string{"create", "-f", yaml_file_path})
 	RootCmd.Execute()
 
-    expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"Test"},"spec":{"visibility":"public","repository":{"url":"git@github.com:/semaphoreci/cli.git","forked_pull_requests":{},"pipeline_file":"","whitelist":{}}}}`
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"Test"},"spec":{"visibility":"public","repository":{"url":"git@github.com:/semaphoreci/cli.git","forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_token"}}}`
 
 	if received != expected {
 		t.Errorf("Expected the API to receive POST projects with: %s, got: %s", expected, received)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,13 +18,13 @@ import (
 )
 
 const (
-	IntegrationTypeGithubToken = "github_token"
-	IntegrationTypeGithubApp   = "github_app"
+	GithubIntegrationOAuthToken = "github_token"
+	GithubIntegrationApp        = "github_app"
 )
 
 var flagProjectName string
 var flagRepoUrl string
-var flagIntegrationType string
+var flagGithubIntegration string
 
 func InitCmd() cobra.Command {
 	cmd := cobra.Command{
@@ -41,10 +41,10 @@ func InitCmd() cobra.Command {
 	cmd.Flags().StringVar(&flagProjectName, "project-name", "", "explicitly set the project name, if not set it is extracted from the repo-url")
 
 	cmd.Flags().StringVar(
-		&flagIntegrationType,
-		"integration-type",
-		"github_token",
-		fmt.Sprintf("integration type for the project. Possible values are: %v", validIntegrationTypes()),
+		&flagGithubIntegration,
+		"github-integration",
+		GithubIntegrationOAuthToken,
+		fmt.Sprintf("github integration for the project. Possible values are: %s", validIntegrationTypes()),
 	)
 
 	return cmd
@@ -77,10 +77,10 @@ func RunInit(cmd *cobra.Command, args []string) {
 		utils.Check(err)
 	}
 
-	if flagIntegrationType != IntegrationTypeGithubToken && flagIntegrationType != IntegrationTypeGithubApp {
+	if flagGithubIntegration != GithubIntegrationOAuthToken && flagGithubIntegration != GithubIntegrationApp {
 		utils.Fail(fmt.Sprintf(
-			"Invalid integration type '%s' for project. Possible values are %v",
-			flagIntegrationType,
+			"Invalid GitHub integration '%s' for project. Possible values are %s",
+			flagGithubIntegration,
 			validIntegrationTypes(),
 		))
 	}
@@ -89,7 +89,7 @@ func RunInit(cmd *cobra.Command, args []string) {
 	projectModel := models.NewProjectV1Alpha(name)
 	projectModel.Spec.Repository.Url = repoUrl
 	projectModel.Spec.Repository.RunOn = []string{"branches", "tags"}
-	projectModel.Spec.Repository.IntegrationType = flagIntegrationType
+	projectModel.Spec.Repository.IntegrationType = flagGithubIntegration
 
 	project, err := c.CreateProject(&projectModel)
 
@@ -150,6 +150,6 @@ func getGitOriginUrl() (string, error) {
 	}
 }
 
-func validIntegrationTypes() []string {
-	return []string{IntegrationTypeGithubToken, IntegrationTypeGithubApp}
+func validIntegrationTypes() string {
+	return fmt.Sprintf("\"%s\" (OAuth token), \"%s\"", GithubIntegrationOAuthToken, GithubIntegrationApp)
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -28,7 +28,7 @@ func TestRunInit__NoParams(t *testing.T) {
 	cmd := InitCmd()
 	cmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"something"},"spec":{"repository":{"url":"git@github.com:/renderedtext/something.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{}}}}`
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"something"},"spec":{"repository":{"url":"git@github.com:/renderedtext/something.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_token"}}}`
 
 	if received != expected {
 		t.Errorf("Expected the API to receive project create req with '%s' instead '%s'.", expected, received)
@@ -59,7 +59,42 @@ func TestRunInit__NameParamPassed(t *testing.T) {
 
 	cmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"another-name"},"spec":{"repository":{"url":"git@github.com:/renderedtext/something.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{}}}}`
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"another-name"},"spec":{"repository":{"url":"git@github.com:/renderedtext/something.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_token"}}}`
+
+	fmt.Print(expected)
+	fmt.Print(received)
+
+	if received != expected {
+		t.Errorf("Expected the API to receive project create req, want: %s got: %s.", expected, received)
+	}
+}
+
+func TestRunInit__IntegrationTypeParamPassed(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := ""
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/projects",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, string(received)), nil
+		},
+	)
+
+	cmd := InitCmd()
+
+	cmd.SetArgs([]string{
+		`--project-name=another-name`,
+		`--integration-type=github_app`,
+	})
+
+	cmd.Execute()
+
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"another-name"},"spec":{"repository":{"url":"git@github.com:/renderedtext/something.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_app"}}}`
 
 	fmt.Print(expected)
 	fmt.Print(received)
@@ -93,7 +128,7 @@ func TestRunInit__RepoUrlParamPassed(t *testing.T) {
 
 	cmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"a"},"spec":{"repository":{"url":"git@github.com:/renderedtext/a.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{}}}}`
+	expected := `{"apiVersion":"v1alpha","kind":"Project","metadata":{"name":"a"},"spec":{"repository":{"url":"git@github.com:/renderedtext/a.git","run_on":["branches","tags"],"forked_pull_requests":{},"pipeline_file":"","whitelist":{},"integration_type":"github_token"}}}`
 
 	fmt.Print(expected)
 	fmt.Print(received)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -89,7 +89,7 @@ func TestRunInit__IntegrationTypeParamPassed(t *testing.T) {
 
 	cmd.SetArgs([]string{
 		`--project-name=another-name`,
-		`--integration-type=github_app`,
+		`--github-integration=github_app`,
 	})
 
 	cmd.Execute()


### PR DESCRIPTION
Adds a new `--integration-type` parameter to the `sem init` command. The possible values are `github_token` (default) and `github_app`. The project API already accepts this parameter, so no changes were required in the API.