### PR TITLE
feat: list/get/create/delete operations for agent_type resource

### DIFF
--- a/api/client/agent_types_v1_alpha.go
+++ b/api/client/agent_types_v1_alpha.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	models "github.com/semaphoreci/cli/api/models"
+)
+
+type AgentTypeApiV1AlphaApi struct {
+	BaseClient           BaseClient
+	ResourceNameSingular string
+	ResourceNamePlural   string
+}
+
+func NewAgentTypeApiV1AlphaApi() AgentTypeApiV1AlphaApi {
+	baseClient := NewBaseClientFromConfig()
+	baseClient.SetApiVersion("v1alpha")
+
+	return AgentTypeApiV1AlphaApi{
+		BaseClient:           baseClient,
+		ResourceNamePlural:   "self_hosted_agent_types",
+		ResourceNameSingular: "self_hosted_agent_type",
+	}
+}
+
+func (c *AgentTypeApiV1AlphaApi) ListAgentTypes() (*models.AgentTypeListV1Alpha, error) {
+	body, status, err := c.BaseClient.List(c.ResourceNamePlural)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewAgentTypeListV1AlphaFromJson(body)
+}
+
+func (c *AgentTypeApiV1AlphaApi) GetAgentType(name string) (*models.AgentTypeV1Alpha, error) {
+	body, status, err := c.BaseClient.Get(c.ResourceNamePlural, name)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewAgentTypeV1AlphaFromJson(body)
+}
+
+func (c *AgentTypeApiV1AlphaApi) DeleteAgentType(name string) error {
+	body, status, err := c.BaseClient.Delete(c.ResourceNamePlural, name)
+
+	if err != nil {
+		return err
+	}
+
+	if status != 200 {
+		return fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return nil
+}
+
+func (c *AgentTypeApiV1AlphaApi) CreateAgentType(d *models.AgentTypeV1Alpha) (*models.AgentTypeV1Alpha, error) {
+	json_body, err := d.ToJson()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failed to serialize object '%s'", err))
+	}
+
+	body, status, err := c.BaseClient.Post(c.ResourceNamePlural, json_body)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("creating %s on Semaphore failed '%s'", c.ResourceNameSingular, err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewAgentTypeV1AlphaFromJson(body)
+}

--- a/api/models/agent_type_list_v1_alpha.go
+++ b/api/models/agent_type_list_v1_alpha.go
@@ -1,0 +1,28 @@
+package models
+
+import "encoding/json"
+
+type AgentTypeListV1Alpha struct {
+	AgentTypes []AgentTypeV1Alpha `json:"agent_types" yaml:"agent_types"`
+}
+
+func NewAgentTypeListV1AlphaFromJson(data []byte) (*AgentTypeListV1Alpha, error) {
+	list := AgentTypeListV1Alpha{}
+
+	err := json.Unmarshal(data, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range list.AgentTypes {
+		if s.ApiVersion == "" {
+			s.ApiVersion = "v1alpha"
+		}
+
+		if s.Kind == "" {
+			s.Kind = "SelfHostedAgentType"
+		}
+	}
+
+	return &list, nil
+}

--- a/api/models/agent_type_v1_alpha.go
+++ b/api/models/agent_type_v1_alpha.go
@@ -1,0 +1,74 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type AgentTypeV1Alpha struct {
+	ApiVersion string                   `json:"apiVersion,omitempty" yaml:"apiVersion"`
+	Kind       string                   `json:"kind,omitempty" yaml:"kind"`
+	Metadata   AgentTypeV1AlphaMetadata `json:"metadata" yaml:"metadata"`
+	Status     AgentTypeV1AlphaStatus   `json:"status" yaml:"status"`
+}
+
+type AgentTypeV1AlphaMetadata struct {
+	Name       string      `json:"name,omitempty" yaml:"name,omitempty"`
+	CreateTime json.Number `json:"create_time,omitempty" yaml:"create_time,omitempty"`
+	UpdateTime json.Number `json:"update_time,omitempty" yaml:"update_time,omitempty"`
+}
+
+type AgentTypeV1AlphaStatus struct {
+	TotalAgentCount   int    `json:"total_agent_count,omitempty" yaml:"total_agent_count,omitempty"`
+	RegistrationToken string `json:"registration_token,omitempty" yaml:"registration_token,omitempty"`
+}
+
+func NewAgentTypeV1Alpha(name string) AgentTypeV1Alpha {
+	a := AgentTypeV1Alpha{}
+	a.Metadata.Name = name
+	a.setApiVersionAndKind()
+	return a
+}
+
+func NewAgentTypeV1AlphaFromJson(data []byte) (*AgentTypeV1Alpha, error) {
+	a := AgentTypeV1Alpha{}
+
+	err := json.Unmarshal(data, &a)
+	if err != nil {
+		return nil, err
+	}
+
+	a.setApiVersionAndKind()
+	return &a, nil
+}
+
+func NewAgentTypeV1AlphaFromYaml(data []byte) (*AgentTypeV1Alpha, error) {
+	a := AgentTypeV1Alpha{}
+
+	err := yaml.UnmarshalStrict(data, &a)
+	if err != nil {
+		return nil, err
+	}
+
+	a.setApiVersionAndKind()
+	return &a, nil
+}
+
+func (s *AgentTypeV1Alpha) setApiVersionAndKind() {
+	s.ApiVersion = "v1alpha"
+	s.Kind = "SelfHostedAgentType"
+}
+
+func (s *AgentTypeV1Alpha) ObjectName() string {
+	return fmt.Sprintf("SelfHostedAgentType/%s", s.Metadata.Name)
+}
+
+func (s *AgentTypeV1Alpha) ToJson() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *AgentTypeV1Alpha) ToYaml() ([]byte, error) {
+	return yaml.Marshal(s)
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -94,6 +94,17 @@ var createCmd = &cobra.Command{
 			utils.Check(err)
 
 			fmt.Printf("Job '%s' created.\n", job.Metadata.Id)
+		case "SelfHostedAgentType":
+			at, err := models.NewAgentTypeV1AlphaFromYaml(data)
+			utils.Check(err)
+
+			c := client.NewAgentTypeApiV1AlphaApi()
+			newAgentType, err := c.CreateAgentType(at)
+			utils.Check(err)
+
+			y, err := newAgentType.ToYaml()
+			utils.Check(err)
+			fmt.Printf("%s", y)
 		default:
 			utils.Fail(fmt.Sprintf("Unsupported resource kind '%s'", kind))
 		}
@@ -118,6 +129,27 @@ var CreateDashboardCmd = &cobra.Command{
 		utils.Check(err)
 
 		fmt.Printf("Dashboard '%s' created.\n", dash.Metadata.Name)
+	},
+}
+
+var CreateAgentTypeCmd = &cobra.Command{
+	Use:     "agent_type [NAME]",
+	Short:   "Create a self-hosted agent type.",
+	Long:    ``,
+	Aliases: []string{"agent_type", "at"},
+	Args:    cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+
+		c := client.NewAgentTypeApiV1AlphaApi()
+		at := models.NewAgentTypeV1Alpha(name)
+		agentType, err := c.CreateAgentType(&at)
+		utils.Check(err)
+
+		y, err := agentType.ToYaml()
+		utils.Check(err)
+		fmt.Printf("%s", y)
 	},
 }
 
@@ -185,6 +217,7 @@ func init() {
 	createCmd.AddCommand(createJobCmd)
 	createCmd.AddCommand(CreateWorkflowCmd)
 	createCmd.AddCommand(createNotificationCmd)
+	createCmd.AddCommand(CreateAgentTypeCmd)
 
 	// Create Flags
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -136,7 +136,7 @@ var CreateAgentTypeCmd = &cobra.Command{
 	Use:     "agent_type [NAME]",
 	Short:   "Create a self-hosted agent type.",
 	Long:    ``,
-	Aliases: []string{"agent_type", "at"},
+	Aliases: []string{"agenttype", "agentType"},
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -199,3 +199,66 @@ func Test__CreateDashboard__WithSubcommand__Response200(t *testing.T) {
 		t.Errorf("Expected the API to receive POST dashboard with: %s, got: %s", expected, received)
 	}
 }
+
+func Test__CreateAgentType__FromYaml__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	yaml_file := `
+apiVersion: v1alpha
+kind: SelfHostedAgentType
+metadata:
+  name: s1-testing-from-yaml
+`
+
+	yaml_file_path := "/tmp/agent_type.yaml"
+
+	ioutil.WriteFile(yaml_file_path, []byte(yaml_file), 0644)
+
+	received := ""
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, received), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"create", "-f", yaml_file_path})
+	RootCmd.Execute()
+
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing-from-yaml"},"status":{}}`
+
+	if received != expected {
+		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)
+	}
+}
+
+func Test__CreateAgentType__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := ""
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, received), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"create", "agent_type", "s1-testing"})
+	RootCmd.Execute()
+
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing"},"status":{}}`
+
+	if received != expected {
+		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)
+	}
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -55,6 +55,23 @@ var DeleteSecretCmd = &cobra.Command{
 	},
 }
 
+var DeleteAgentTypeCmd = &cobra.Command{
+	Use:     "agent_type [NAME]",
+	Short:   "Delete a self-hosted agent type.",
+	Long:    ``,
+	Aliases: []string{"agent_Type"},
+	Args:    cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+		c := client.NewAgentTypeApiV1AlphaApi()
+		err := c.DeleteAgentType(name)
+		utils.Check(err)
+
+		fmt.Printf("Self-hosted agent type '%s' deleted.\n", name)
+	},
+}
+
 var DeleteProjectCmd = &cobra.Command{
 	Use:     "project [NAME]",
 	Short:   "Delete a project.",
@@ -102,4 +119,5 @@ func init() {
 	deleteCmd.AddCommand(DeleteProjectCmd)
 	deleteCmd.AddCommand(DeleteSecretCmd)
 	deleteCmd.AddCommand(DeleteNotificationCmd)
+	deleteCmd.AddCommand(DeleteAgentTypeCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -59,7 +59,7 @@ var DeleteAgentTypeCmd = &cobra.Command{
 	Use:     "agent_type [NAME]",
 	Short:   "Delete a self-hosted agent type.",
 	Long:    ``,
-	Aliases: []string{"agent_Type"},
+	Aliases: []string{"agenttype", "agentType"},
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -72,3 +72,25 @@ func TestDeleteDashboardCmd__Response200(t *testing.T) {
 		t.Error("Expected the API to receive DELETE test dash")
 	}
 }
+
+func TestDeleteAgentTypeCmd__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("DELETE", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types/s1-testing",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			return httpmock.NewStringResponse(200, ""), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"delete", "agent_type", "s1-testing"})
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive DELETE agent_type s1-testing")
+	}
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -110,6 +110,49 @@ var GetSecretCmd = &cobra.Command{
 	},
 }
 
+var GetAgentTypeCmd = &cobra.Command{
+	Use:     "agent_types [name]",
+	Short:   "Get self-hosted agent types.",
+	Long:    ``,
+	Aliases: []string{"agent_type"},
+	Args:    cobra.RangeArgs(0, 1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		c := client.NewAgentTypeApiV1AlphaApi()
+
+		if len(args) == 0 {
+			agentTypeList, err := c.ListAgentTypes()
+
+			utils.Check(err)
+
+			const padding = 3
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+
+			fmt.Fprintln(w, "NAME\tAGE")
+
+			for _, a := range agentTypeList.AgentTypes {
+				updateTime, err := a.Metadata.UpdateTime.Int64()
+				utils.Check(err)
+				fmt.Fprintf(w, "%s\t%s\n", a.Metadata.Name, utils.RelativeAgeForHumans(updateTime))
+			}
+
+			w.Flush()
+		} else {
+			name := args[0]
+
+			secret, err := c.GetAgentType(name)
+
+			utils.Check(err)
+
+			y, err := secret.ToYaml()
+
+			utils.Check(err)
+
+			fmt.Printf("%s", y)
+		}
+	},
+}
+
 var GetProjectCmd = &cobra.Command{
 	Use:     "projects [name]",
 	Short:   "Get projects.",
@@ -283,6 +326,7 @@ func init() {
 	getCmd.AddCommand(getNotificationCmd)
 	getCmd.AddCommand(GetSecretCmd)
 	getCmd.AddCommand(GetProjectCmd)
+	getCmd.AddCommand(GetAgentTypeCmd)
 
 	GetJobCmd.Flags().BoolVar(&GetJobAllStates, "all", false, "list all jobs including finished ones")
 	getCmd.AddCommand(GetJobCmd)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -114,7 +114,7 @@ var GetAgentTypeCmd = &cobra.Command{
 	Use:     "agent_types [name]",
 	Short:   "Get self-hosted agent types.",
 	Long:    ``,
-	Aliases: []string{"agent_type"},
+	Aliases: []string{"agent_type", "agenttype", "agenttypes", "agentTypes", "agentType"},
 	Args:    cobra.RangeArgs(0, 1),
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	httpmock "gopkg.in/jarcoal/httpmock.v1"
 	"github.com/stretchr/testify/assert"
+	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
 
 func Test__ListProjects__Response200(t *testing.T) {
@@ -289,6 +289,39 @@ func Test__GetSecret__Response200(t *testing.T) {
 
 	if received == false {
 		t.Error("Expected the API to receive GET secrets/aaaaaaa")
+	}
+}
+
+func Test__GetAgentType__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types/s1-testing",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			a1 := `{
+				"metadata":{
+					"name":"s1-testing",
+					"create_time":1536673464,
+					"update_time":1536674946
+				},
+				"status":{
+					"total_agent_count":0
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, a1), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "agent_type", "s1-testing"})
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET self_hosted_agent_types/s1-testing")
 	}
 }
 


### PR DESCRIPTION
Adds the operations for the new v1alpha API for self-hosted agent types.