### PR TITLE
Add project level secrets

### DIFF
--- a/api/client/project_secrets_v1.go
+++ b/api/client/project_secrets_v1.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	models "github.com/semaphoreci/cli/api/models"
+)
+
+type ProjectSecretsApiV1Api struct {
+	BaseClient           BaseClient
+	ResourceNameSingular string
+	ResourceNamePlural   string
+}
+
+func NewProjectSecretV1Api(projectID string) ProjectSecretsApiV1Api {
+	baseClient := NewBaseClientFromConfig()
+	baseClient.SetApiVersion("v1")
+
+	return ProjectSecretsApiV1Api{
+		BaseClient:           baseClient,
+		ResourceNamePlural:   fmt.Sprintf("projects/%s/secrets", projectID),
+		ResourceNameSingular: fmt.Sprintf("projects/%s/secret", projectID),
+	}
+}
+
+func (c *ProjectSecretsApiV1Api) ListSecrets() (*models.SecretListV1Beta, error) {
+	body, status, err := c.BaseClient.List(c.ResourceNamePlural)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewSecretListV1BetaFromJson(body)
+}
+
+func (c *ProjectSecretsApiV1Api) GetSecret(name string) (*models.ProjectSecretV1, error) {
+	body, status, err := c.BaseClient.Get(c.ResourceNamePlural, name)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewProjectSecretV1FromJson(body)
+}
+
+func (c *ProjectSecretsApiV1Api) DeleteSecret(name string) error {
+	body, status, err := c.BaseClient.Delete(c.ResourceNamePlural, name)
+
+	if err != nil {
+		return err
+	}
+
+	if status != 200 {
+		return fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return nil
+}
+
+func (c *ProjectSecretsApiV1Api) CreateSecret(d *models.ProjectSecretV1) (*models.ProjectSecretV1, error) {
+	json_body, err := d.ToJson()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failed to serialize object '%s'", err))
+	}
+
+	body, status, err := c.BaseClient.Post(c.ResourceNamePlural, json_body)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("creating %s on Semaphore failed '%s'", c.ResourceNameSingular, err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewProjectSecretV1FromJson(body)
+}
+
+func (c *ProjectSecretsApiV1Api) UpdateSecret(d *models.ProjectSecretV1) (*models.ProjectSecretV1, error) {
+	json_body, err := d.ToJson()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failed to serialize %s object '%s'", c.ResourceNameSingular, err))
+	}
+
+	identifier := ""
+
+	if d.Metadata.Id != "" {
+		identifier = d.Metadata.Id
+	} else {
+		identifier = d.Metadata.Name
+	}
+
+	body, status, err := c.BaseClient.Patch(c.ResourceNamePlural, identifier, json_body)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("updating %s on Semaphore failed '%s'", c.ResourceNamePlural, err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewProjectSecretV1FromJson(body)
+}

--- a/api/models/project_secret_list_v1.go
+++ b/api/models/project_secret_list_v1.go
@@ -1,0 +1,29 @@
+package models
+
+import "encoding/json"
+
+type ProjectSecretListV1 struct {
+	Secrets []ProjectSecretV1 `json:"secrets" yaml:"secrets"`
+}
+
+func NewProjectSecretListV1FromJson(data []byte) (*ProjectSecretListV1, error) {
+	list := ProjectSecretListV1{}
+
+	err := json.Unmarshal(data, &list)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range list.Secrets {
+		if s.ApiVersion == "" {
+			s.ApiVersion = "v1"
+		}
+
+		if s.Kind == "" {
+			s.Kind = "Secret"
+		}
+	}
+
+	return &list, nil
+}

--- a/api/models/project_secret_v1.go
+++ b/api/models/project_secret_v1.go
@@ -1,0 +1,95 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type ProjectSecretV1 struct {
+	ApiVersion string `json:"apiVersion,omitempty" yaml:"apiVersion"`
+	Kind       string `json:"kind,omitempty" yaml:"kind"`
+
+	Metadata ProjectSecretV1Metadata `json:"metadata" yaml:"metadata"`
+	Data     ProjectSecretV1Data     `json:"data" yaml:"data"`
+}
+
+type ProjectSecretV1EnvVar struct {
+	Name  string `json:"name" yaml:"name"`
+	Value string `json:"value" yaml:"value"`
+}
+
+type ProjectSecretV1File struct {
+	Path    string `json:"path" yaml:"path"`
+	Content string `json:"content" yaml:"content"`
+}
+
+type ProjectSecretV1Data struct {
+	EnvVars []ProjectSecretV1EnvVar `json:"env_vars" yaml:"env_vars"`
+	Files   []ProjectSecretV1File   `json:"files" yaml: "files"`
+}
+
+type ProjectSecretV1Metadata struct {
+	Name       string      `json:"name,omitempty" yaml:"name,omitempty"`
+	Id         string      `json:"id,omitempty" yaml:"id,omitempty"`
+	CreateTime json.Number `json:"create_time,omitempty,string" yaml:"create_time,omitempty"`
+	UpdateTime json.Number `json:"update_time,omitempty,string" yaml:"update_time,omitempty"`
+	ProjectIdOrName string `json:"project_id_or_name,omitempty" yaml:"project_id_or_name,omitempty"`
+}
+
+func NewProjectSecretV1(name string, envVars []ProjectSecretV1EnvVar, files []ProjectSecretV1File) ProjectSecretV1 {
+	s := ProjectSecretV1{}
+
+	s.setApiVersionAndKind()
+	s.Metadata.Name = name
+	s.Data.EnvVars = envVars
+	s.Data.Files = files
+
+	return s
+}
+
+func NewProjectSecretV1FromJson(data []byte) (*ProjectSecretV1, error) {
+	s := ProjectSecretV1{}
+
+	err := json.Unmarshal(data, &s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s.setApiVersionAndKind()
+
+	return &s, nil
+}
+
+func NewProjectSecretV1FromYaml(data []byte) (*ProjectSecretV1, error) {
+	s := ProjectSecretV1{}
+
+	err := yaml.UnmarshalStrict(data, &s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s.setApiVersionAndKind()
+
+	return &s, nil
+}
+
+func (s *ProjectSecretV1) setApiVersionAndKind() {
+	s.ApiVersion = "v1"
+	s.Kind = "ProjectSecret"
+}
+
+func (s *ProjectSecretV1) ObjectName() string {
+	return fmt.Sprintf("Project/%s/Secrets/%s", s.Metadata.ProjectIdOrName, s.Metadata.Name)
+}
+
+func (s *ProjectSecretV1) ToJson() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *ProjectSecretV1) ToYaml() ([]byte, error) {
+	return yaml.Marshal(s)
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -53,6 +53,18 @@ func RunApply(cmd *cobra.Command, args []string) {
 		utils.Check(err)
 
 		fmt.Printf("Secret '%s' updated.\n", secret.Metadata.Name)
+	case "ProjectSecret":
+		secret, err := models.NewProjectSecretV1FromYaml(data)
+
+		utils.Check(err)
+
+		c := client.NewProjectSecretV1Api(secret.Metadata.ProjectIdOrName)
+
+		secret, err = c.UpdateSecret(secret)
+
+		utils.Check(err)
+
+		fmt.Printf("Secret '%s' created in project '%s'.\n", secret.Metadata.Name, secret.Metadata.ProjectIdOrName)
 	case "Dashboard":
 		dash, err := models.NewDashboardV1AlphaFromYaml(data)
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -70,6 +70,18 @@ var createCmd = &cobra.Command{
 			utils.Check(err)
 
 			fmt.Printf("Secret '%s' created.\n", secret.Metadata.Name)
+		case "ProjectSecret":
+			secret, err := models.NewProjectSecretV1FromYaml(data)
+
+			utils.Check(err)
+
+			c := client.NewProjectSecretV1Api(secret.Metadata.ProjectIdOrName)
+
+			_, err = c.CreateSecret(secret)
+
+			utils.Check(err)
+
+			fmt.Printf("Secret '%s' created in project '%s'.\n", secret.Metadata.Name, secret.Metadata.ProjectIdOrName)
 		case "Dashboard":
 			dash, err := models.NewDashboardV1AlphaFromYaml(data)
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -38,20 +38,33 @@ var DeleteDashboardCmd = &cobra.Command{
 var DeleteSecretCmd = &cobra.Command{
 	Use:     "secret [NAME]",
 	Short:   "Delete a secret.",
-	Long:    ``,
+	Long:    `Delete a organization or project secret. To delete a project secret, use the --project-name or --project-id flag.`,
 	Aliases: []string{"secrets"},
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		name := args[0]
+		projectID := GetPrjIfPresent(cmd)
 
-		c := client.NewSecretV1BetaApi()
+		if projectID == "" {
+			name := args[0]
 
-		err := c.DeleteSecret(name)
+			c := client.NewSecretV1BetaApi()
 
-		utils.Check(err)
+			err := c.DeleteSecret(name)
 
-		fmt.Printf("Secret '%s' deleted.\n", name)
+			utils.Check(err)
+
+			fmt.Printf("Secret '%s' deleted.\n", name)
+		} else {
+			name := args[0]
+			c := client.NewProjectSecretV1Api(projectID)
+
+			err := c.DeleteSecret(name)
+
+			utils.Check(err)
+
+			fmt.Printf("Secret '%s' deleted.\n", name)
+		}
 	},
 }
 
@@ -117,7 +130,12 @@ func init() {
 
 	deleteCmd.AddCommand(DeleteDashboardCmd)
 	deleteCmd.AddCommand(DeleteProjectCmd)
-	deleteCmd.AddCommand(DeleteSecretCmd)
 	deleteCmd.AddCommand(DeleteNotificationCmd)
 	deleteCmd.AddCommand(DeleteAgentTypeCmd)
+
+	DeleteSecretCmd.Flags().StringP("project-name", "p", "",
+		"project name; if specified will delete project secret, otherwise organization secret")
+	DeleteSecretCmd.Flags().StringP("project-id", "i", "",
+		"project id; if specified will delete project secret, otherwise organization secret")
+	deleteCmd.AddCommand(DeleteSecretCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -43,7 +43,7 @@ var DeleteSecretCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		projectID := GetPrjIfPresent(cmd)
+		projectID := GetProjectID(cmd)
 
 		if projectID == "" {
 			name := args[0]

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -95,31 +95,61 @@ var EditSecretCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		name := args[0]
+		projectID := GetPrjIfPresent(cmd)
 
-		c := client.NewSecretV1BetaApi()
+		if projectID == "" {
+			name := args[0]
 
-		secret, err := c.GetSecret(name)
+			c := client.NewSecretV1BetaApi()
 
-		utils.Check(err)
+			secret, err := c.GetSecret(name)
 
-		content, err := secret.ToYaml()
+			utils.Check(err)
 
-		utils.Check(err)
+			content, err := secret.ToYaml()
 
-		new_content, err := utils.EditYamlInEditor(secret.ObjectName(), string(content))
+			utils.Check(err)
 
-		utils.Check(err)
+			new_content, err := utils.EditYamlInEditor(secret.ObjectName(), string(content))
 
-		updated_secret, err := models.NewSecretV1BetaFromYaml([]byte(new_content))
+			utils.Check(err)
 
-		utils.Check(err)
+			updated_secret, err := models.NewSecretV1BetaFromYaml([]byte(new_content))
 
-		secret, err = c.UpdateSecret(updated_secret)
+			utils.Check(err)
 
-		utils.Check(err)
+			secret, err = c.UpdateSecret(updated_secret)
 
-		fmt.Printf("Secret '%s' updated.\n", secret.Metadata.Name)
+			utils.Check(err)
+
+			fmt.Printf("Secret '%s' updated.\n", secret.Metadata.Name)
+		} else {
+			name := args[0]
+
+			c := client.NewProjectSecretV1Api(projectID)
+
+			secret, err := c.GetSecret(name)
+
+			utils.Check(err)
+
+			content, err := secret.ToYaml()
+
+			utils.Check(err)
+
+			new_content, err := utils.EditYamlInEditor(secret.ObjectName(), string(content))
+
+			utils.Check(err)
+
+			updated_secret, err := models.NewProjectSecretV1FromYaml([]byte(new_content))
+
+			utils.Check(err)
+
+			secret, err = c.UpdateSecret(updated_secret)
+
+			utils.Check(err)
+
+			fmt.Printf("Secret '%s' updated.\n", secret.Metadata.Name)
+		}
 	},
 }
 
@@ -162,6 +192,10 @@ var EditProjectCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(editCmd)
 
+	EditSecretCmd.Flags().StringP("project-name", "p", "",
+		"project name; if specified will edit project level secret, otherwise organization secret")
+	EditSecretCmd.Flags().StringP("project-id", "i", "",
+		"project id; if specified will edit project level secret, otherwise organization secret")
 	editCmd.AddCommand(EditSecretCmd)
 	editCmd.AddCommand(EditDashboardCmd)
 	editCmd.AddCommand(EditNotificationCmd)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -95,7 +95,7 @@ var EditSecretCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		projectID := GetPrjIfPresent(cmd)
+		projectID := GetProjectID(cmd)
 
 		if projectID == "" {
 			name := args[0]

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -73,7 +73,7 @@ var GetSecretCmd = &cobra.Command{
 	Args:    cobra.RangeArgs(0, 1),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		projectID := GetPrjIfPresent(cmd)
+		projectID := GetProjectID(cmd)
 
 		if projectID == "" {
 			c := client.NewSecretV1BetaApi()
@@ -334,7 +334,7 @@ var GetWfCmd = &cobra.Command{
 	},
 }
 
-func GetPrjIfPresent(cmd *cobra.Command) string {
+func GetProjectID(cmd *cobra.Command) string {
 	projectID, err := cmd.Flags().GetString("project-id")
 	if projectID != "" {
 		return projectID


### PR DESCRIPTION
Adds project level secrets to sem cli
it extends the CLI for secrets from:
```
sem get secrets
sem get secret [name]
sem edit secret [name]
sem apply [-f yaml_file]
sem create secret [name]
sem delete secret [name]
```
to now have a optional flag `--project-name` or `--project-id` 
```
sem get secrets --project-name[--project-id] [project_id_or_name]
sem get secret --project-name[--project-id] [project_id_or_name] [name]
sem edit secret [name] --project-name[--project-id] [project_id_or_name]
sem apply [-f yaml_file]
sem create secret -f yaml_file
sem delete secret [name] --project-name[--project-id] [project_id_or_name]
```
when this flag is present we are going to project level secrets.
For apply and create there is new resource kind `ProjectSecret` to distinguish from organization level secrets, it is also required to provide project id or name in secret metadata.