### PR TITLE
feat: add troubleshoot command

### DIFF
--- a/api/client/troubleshoot_v1_alpha.go
+++ b/api/client/troubleshoot_v1_alpha.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"fmt"
+
+	models "github.com/semaphoreci/cli/api/models"
+)
+
+type TroubleshootApiV1AlphaApi struct {
+	BaseClient           BaseClient
+	ResourceNameSingular string
+	ResourceNamePlural   string
+}
+
+func NewTroubleshootV1AlphaApi() TroubleshootApiV1AlphaApi {
+	baseClient := NewBaseClientFromConfig()
+	baseClient.SetApiVersion("v1alpha")
+
+	return TroubleshootApiV1AlphaApi{
+		BaseClient:           baseClient,
+		ResourceNamePlural:   "troubleshoot",
+		ResourceNameSingular: "troubleshoot",
+	}
+}
+
+func (c *TroubleshootApiV1AlphaApi) TroubleshootWorkflow(workflowID string) (*models.TroubleshootV1Alpha, error) {
+	urlEncode := fmt.Sprintf("%s/workflow", c.ResourceNamePlural)
+	body, status, err := c.BaseClient.Get(urlEncode, workflowID)
+
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewTroubleshootV1AlphaFromJson(body)
+}
+
+func (c *TroubleshootApiV1AlphaApi) TroubleshootJob(jobID string) (*models.TroubleshootV1Alpha, error) {
+	urlEncode := fmt.Sprintf("%s/job", c.ResourceNamePlural)
+	body, status, err := c.BaseClient.Get(urlEncode, jobID)
+
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewTroubleshootV1AlphaFromJson(body)
+}
+
+func (c *TroubleshootApiV1AlphaApi) TroubleshootPipeline(pplID string) (*models.TroubleshootV1Alpha, error) {
+	urlEncode := fmt.Sprintf("%s/pipeline/", c.ResourceNamePlural)
+	body, status, err := c.BaseClient.Get(urlEncode, pplID)
+
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewTroubleshootV1AlphaFromJson(body)
+}

--- a/api/models/troubleshoot_v1_alpha.go
+++ b/api/models/troubleshoot_v1_alpha.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"encoding/json"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type TroubleshootV1Alpha struct {
+	Workflow map[string]interface{} `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+	Project  map[string]interface{} `json:"project,omitempty" yaml:"project,omitempty"`
+	Pipeline map[string]interface{} `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
+	Job      map[string]interface{} `json:"job,omitempty" yaml:"job,omitempty"`
+	Block    map[string]interface{} `json:"block,omitempty" yaml:"block,omitempty"`
+}
+
+func NewTroubleshootV1AlphaFromJson(data []byte) (*TroubleshootV1Alpha, error) {
+	t := TroubleshootV1Alpha{}
+	err := json.Unmarshal(data, &t)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func (j *TroubleshootV1Alpha) ToJson() ([]byte, error) {
+	return json.Marshal(j)
+}
+
+func (j *TroubleshootV1Alpha) ToYaml() ([]byte, error) {
+	return yaml.Marshal(j)
+}

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+
+	client "github.com/semaphoreci/cli/api/client"
+	"github.com/semaphoreci/cli/cmd/utils"
+	"github.com/spf13/cobra"
+)
+
+var troubleshootCmd = &cobra.Command{
+	Use:   "troubleshoot [KIND]",
+	Short: "Troubleshoot resource.",
+	Long:  ``,
+	Args:  cobra.RangeArgs(1, 2),
+}
+
+var troubleshootPipelineCmd = &cobra.Command{
+	Use:     "pipeline [id]",
+	Short:   "Troubleshoot pipeline.",
+	Long:    ``,
+	Aliases: []string{"pipelines", "ppl"},
+	Args:    cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		troubleshootClient := client.NewTroubleshootV1AlphaApi()
+		t, err := troubleshootClient.TroubleshootPipeline(id)
+		utils.Check(err)
+
+		v, err := t.ToYaml()
+		utils.Check(err)
+		fmt.Printf("%s", v)
+	},
+}
+
+var troubleshootJobCmd = &cobra.Command{
+	Use:     "job [id]",
+	Short:   "Troubleshoot job.",
+	Long:    ``,
+	Aliases: []string{"jobs"},
+	Args:    cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		troubleshootClient := client.NewTroubleshootV1AlphaApi()
+		t, err := troubleshootClient.TroubleshootJob(id)
+		utils.Check(err)
+
+		v, err := t.ToYaml()
+		utils.Check(err)
+		fmt.Printf("%s", v)
+	},
+}
+
+var troubleshootWorkflowCmd = &cobra.Command{
+	Use:     "workflow [id]",
+	Short:   "Troubleshoot workflow.",
+	Long:    ``,
+	Aliases: []string{"workflows", "wf"},
+	Args:    cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		troubleshootClient := client.NewTroubleshootV1AlphaApi()
+		t, err := troubleshootClient.TroubleshootWorkflow(id)
+		utils.Check(err)
+
+		v, err := t.ToYaml()
+		utils.Check(err)
+		fmt.Printf("%s", v)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(troubleshootCmd)
+
+	troubleshootCmd.AddCommand(troubleshootPipelineCmd)
+	troubleshootCmd.AddCommand(troubleshootJobCmd)
+	troubleshootCmd.AddCommand(troubleshootWorkflowCmd)
+}


### PR DESCRIPTION
Adds a new `sem troubleshoot` command, which assists customers when opening support cases (especially for on-premise installations). The command has three sub-commands:
- `sem troubleshoot job JOB_ID`
- `sem troubleshoot pipeline PIPELINE_ID`
- `sem troubleshoot workflow WORKFLOW_ID`

This makes it easy for a customer to provide all the information required to troubleshoot things from our side.