### PR TITLE
feat: self-hosted agent get/list command

### DIFF
--- a/api/client/agent_v1_alpha.go
+++ b/api/client/agent_v1_alpha.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+
+	models "github.com/semaphoreci/cli/api/models"
+)
+
+type AgentApiV1AlphaApi struct {
+	BaseClient           BaseClient
+	ResourceNameSingular string
+	ResourceNamePlural   string
+}
+
+func NewAgentApiV1AlphaApi() AgentApiV1AlphaApi {
+	baseClient := NewBaseClientFromConfig()
+	baseClient.SetApiVersion("v1alpha")
+
+	return AgentApiV1AlphaApi{
+		BaseClient:           baseClient,
+		ResourceNamePlural:   "self_hosted_agents",
+		ResourceNameSingular: "self_hosted_agent",
+	}
+}
+
+func (c *AgentApiV1AlphaApi) ListAgents(agentType string, next int64) (*models.AgentListV1Alpha, error) {
+	query := url.Values{}
+	query.Add("count", "200")
+
+	if agentType != "" {
+		query.Add("agent_type", agentType)
+	}
+
+	if next > 0 {
+		query.Add("next", fmt.Sprintf("%d", next))
+	}
+
+	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewAgentListV1AlphaFromJson(body)
+}
+
+func (c *AgentApiV1AlphaApi) GetAgent(name string) (*models.AgentV1Alpha, error) {
+	body, status, err := c.BaseClient.Get(c.ResourceNamePlural, name)
+
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewAgentV1AlphaFromJson(body)
+}

--- a/api/client/agent_v1_alpha.go
+++ b/api/client/agent_v1_alpha.go
@@ -19,21 +19,21 @@ func NewAgentApiV1AlphaApi() AgentApiV1AlphaApi {
 
 	return AgentApiV1AlphaApi{
 		BaseClient:           baseClient,
-		ResourceNamePlural:   "self_hosted_agents",
-		ResourceNameSingular: "self_hosted_agent",
+		ResourceNamePlural:   "agents",
+		ResourceNameSingular: "agent",
 	}
 }
 
-func (c *AgentApiV1AlphaApi) ListAgents(agentType string, next int64) (*models.AgentListV1Alpha, error) {
+func (c *AgentApiV1AlphaApi) ListAgents(agentType string, cursor string) (*models.AgentListV1Alpha, error) {
 	query := url.Values{}
-	query.Add("count", "200")
+	query.Add("page_size", "200")
 
 	if agentType != "" {
 		query.Add("agent_type", agentType)
 	}
 
-	if next > 0 {
-		query.Add("next", fmt.Sprintf("%d", next))
+	if cursor != "" {
+		query.Add("cursor", cursor)
 	}
 
 	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)

--- a/api/models/agent_list_v1_alpha.go
+++ b/api/models/agent_list_v1_alpha.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type AgentListV1Alpha struct {
 	Agents []AgentV1Alpha `json:"agents" yaml:"agents"`
-	Next   int64          `json:"next" yaml:"next"`
+	Cursor string         `json:"cursor" yaml:"cursor"`
 }
 
 func NewAgentListV1AlphaFromJson(data []byte) (*AgentListV1Alpha, error) {

--- a/api/models/agent_list_v1_alpha.go
+++ b/api/models/agent_list_v1_alpha.go
@@ -1,0 +1,29 @@
+package models
+
+import "encoding/json"
+
+type AgentListV1Alpha struct {
+	Agents []AgentV1Alpha `json:"agents" yaml:"agents"`
+	Next   int64          `json:"next" yaml:"next"`
+}
+
+func NewAgentListV1AlphaFromJson(data []byte) (*AgentListV1Alpha, error) {
+	list := AgentListV1Alpha{}
+
+	err := json.Unmarshal(data, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range list.Agents {
+		if s.ApiVersion == "" {
+			s.ApiVersion = "v1alpha"
+		}
+
+		if s.Kind == "" {
+			s.Kind = "SelfHostedAgent"
+		}
+	}
+
+	return &list, nil
+}

--- a/api/models/agent_v1_alpha.go
+++ b/api/models/agent_v1_alpha.go
@@ -1,0 +1,80 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type AgentV1Alpha struct {
+	ApiVersion string               `json:"apiVersion,omitempty" yaml:"apiVersion"`
+	Kind       string               `json:"kind,omitempty" yaml:"kind"`
+	Metadata   AgentV1AlphaMetadata `json:"metadata" yaml:"metadata"`
+	Status     AgentV1AlphaStatus   `json:"status" yaml:"status"`
+}
+
+type AgentV1AlphaMetadata struct {
+	Name        string      `json:"name,omitempty" yaml:"name,omitempty"`
+	Type        string      `json:"type,omitempty" yaml:"type,omitempty"`
+	ConnectedAt json.Number `json:"connected_at,omitempty" yaml:"connected_at,omitempty"`
+	DisabledAt  json.Number `json:"disabled_at,omitempty" yaml:"disabled_at,omitempty"`
+	Version     string      `json:"version,omitempty" yaml:"version,omitempty"`
+	OS          string      `json:"os,omitempty" yaml:"os,omitempty"`
+	Arch        string      `json:"arch,omitempty" yaml:"arch,omitempty"`
+	Hostname    string      `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+	IPAddress   string      `json:"ip_address,omitempty" yaml:"ip_address,omitempty"`
+	PID         json.Number `json:"pid,omitempty" yaml:"pid,omitempty"`
+}
+
+type AgentV1AlphaStatus struct {
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+}
+
+func NewAgentV1Alpha(name string) AgentV1Alpha {
+	a := AgentV1Alpha{}
+	a.Metadata.Name = name
+	a.setApiVersionAndKind()
+	return a
+}
+
+func NewAgentV1AlphaFromJson(data []byte) (*AgentV1Alpha, error) {
+	a := AgentV1Alpha{}
+
+	err := json.Unmarshal(data, &a)
+	if err != nil {
+		return nil, err
+	}
+
+	a.setApiVersionAndKind()
+	return &a, nil
+}
+
+func NewAgentV1AlphaFromYaml(data []byte) (*AgentV1Alpha, error) {
+	a := AgentV1Alpha{}
+
+	err := yaml.UnmarshalStrict(data, &a)
+	if err != nil {
+		return nil, err
+	}
+
+	a.setApiVersionAndKind()
+	return &a, nil
+}
+
+func (s *AgentV1Alpha) setApiVersionAndKind() {
+	s.ApiVersion = "v1alpha"
+	s.Kind = "SelfHostedAgent"
+}
+
+func (s *AgentV1Alpha) ObjectName() string {
+	return fmt.Sprintf("SelfHostedAgent/%s", s.Metadata.Name)
+}
+
+func (s *AgentV1Alpha) ToJson() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *AgentV1Alpha) ToYaml() ([]byte, error) {
+	return yaml.Marshal(s)
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -232,11 +232,11 @@ var GetAgentsCmd = &cobra.Command{
 		} else {
 			name := args[0]
 
-			secret, err := c.GetAgent(name)
+			agent, err := c.GetAgent(name)
 
 			utils.Check(err)
 
-			y, err := secret.ToYaml()
+			y, err := agent.ToYaml()
 
 			utils.Check(err)
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -247,20 +247,20 @@ var GetAgentsCmd = &cobra.Command{
 
 func getAllAgents(client client.AgentApiV1AlphaApi, agentType string) ([]models.AgentV1Alpha, error) {
 	agents := []models.AgentV1Alpha{}
-	next := int64(0)
+	cursor := ""
 
 	for {
-		agentList, err := client.ListAgents(agentType, next)
+		agentList, err := client.ListAgents(agentType, cursor)
 		if err != nil {
 			return nil, err
 		}
 
 		agents = append(agents, agentList.Agents...)
-		if agentList.Next == 0 {
+		if agentList.Cursor == "" {
 			break
 		}
 
-		next = agentList.Next
+		cursor = agentList.Cursor
 	}
 
 	return agents, nil

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	client "github.com/semaphoreci/cli/api/client"
+	"github.com/semaphoreci/cli/api/models"
 	"github.com/semaphoreci/cli/cmd/pipelines"
 	"github.com/semaphoreci/cli/cmd/utils"
 	"github.com/semaphoreci/cli/cmd/workflows"
@@ -189,6 +190,80 @@ var GetAgentTypeCmd = &cobra.Command{
 			fmt.Printf("%s", y)
 		}
 	},
+}
+
+var GetAgentsCmd = &cobra.Command{
+	Use:     "agents",
+	Short:   "Get self-hosted agents.",
+	Long:    ``,
+	Aliases: []string{"agent"},
+	Args:    cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		c := client.NewAgentApiV1AlphaApi()
+
+		if len(args) == 0 {
+			agentType, err := cmd.Flags().GetString("agent-type")
+			utils.Check(err)
+
+			agents, err := getAllAgents(c, agentType)
+			utils.Check(err)
+
+			if len(agents) == 0 {
+				fmt.Fprintln(os.Stdout, "No agents found")
+				return
+			}
+
+			const padding = 3
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+
+			fmt.Fprintln(w, "NAME\tTYPE\tSTATE\tAGE")
+			for _, a := range agents {
+				connectedAt, err := a.Metadata.ConnectedAt.Int64()
+				utils.Check(err)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					a.Metadata.Name,
+					a.Metadata.Type,
+					a.Status.State,
+					utils.RelativeAgeForHumans(connectedAt),
+				)
+			}
+
+			w.Flush()
+		} else {
+			name := args[0]
+
+			secret, err := c.GetAgent(name)
+
+			utils.Check(err)
+
+			y, err := secret.ToYaml()
+
+			utils.Check(err)
+
+			fmt.Printf("%s", y)
+		}
+	},
+}
+
+func getAllAgents(client client.AgentApiV1AlphaApi, agentType string) ([]models.AgentV1Alpha, error) {
+	agents := []models.AgentV1Alpha{}
+	next := int64(0)
+
+	for {
+		agentList, err := client.ListAgents(agentType, next)
+		if err != nil {
+			return nil, err
+		}
+
+		agents = append(agents, agentList.Agents...)
+		if agentList.Next == 0 {
+			break
+		}
+
+		next = agentList.Next
+	}
+
+	return agents, nil
 }
 
 var GetProjectCmd = &cobra.Command{
@@ -383,6 +458,10 @@ func init() {
 	getCmd.AddCommand(getNotificationCmd)
 	getCmd.AddCommand(GetProjectCmd)
 	getCmd.AddCommand(GetAgentTypeCmd)
+
+	GetAgentsCmd.Flags().StringP("agent-type", "t", "",
+		"agent type; if specified, returns only agents for this agent type")
+	getCmd.AddCommand(GetAgentsCmd)
 
 	GetSecretCmd.Flags().StringP("project-name", "p", "",
 		"project name; if specified will get secret from project level, otherwise organization secret")

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -331,7 +331,7 @@ func Test__GetAgent__Response200(t *testing.T) {
 
 	received := false
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agents/asdfasdfadsf",
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/agents/asdfasdfadsf",
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 
@@ -355,7 +355,7 @@ func Test__GetAgent__Response200(t *testing.T) {
 	RootCmd.Execute()
 
 	if received == false {
-		t.Error("Expected the API to receive GET self_hosted_agents/asdfasdfadsf")
+		t.Error("Expected the API to receive GET agents/asdfasdfadsf")
 	}
 }
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -325,6 +325,40 @@ func Test__GetAgentType__Response200(t *testing.T) {
 	}
 }
 
+func Test__GetAgent__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agents/asdfasdfadsf",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			a1 := `{
+				"metadata":{
+					"name":"s1-testing",
+					"type":"asdfasdfadsf",
+					"connected_at":1536673464,
+					"disabled_at":1536674946
+				},
+				"status":{
+					"state":"waiting_for_job"
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, a1), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "agent", "asdfasdfadsf"})
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET self_hosted_agents/asdfasdfadsf")
+	}
+}
+
 func Test__GetPipeline__Response200(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
Adds a new get command to list/describe self-hosted agents:

```
» sem get agents
NAME       TYPE         STATE           AGE
my-agent-1 s1-aws-small waiting_for_job 12m
my-agent-2 s1-aws-small waiting_for_job 10m
my-agent-3 s1-aws-small running_job      8m
my-agent-3 s1-aws-large waiting_for_job  1m

» sem get agent my-agent-1
apiVersion: v1alpha
kind: SelfHostedAgent
metadata:
  name: my-agent-1
  type: s1-aws-small
  connected_at: 1686789756
  version: v2.2.6
  os: Ubuntu 22.04
  arch: x86_64
  hostname: agenthostname
  ip_address: 0.0.0.0
  pid: 0
status:
  state: waiting_for_job
```