### PR TITLE
Introduce `sem validate FILE` to check pipeline files

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	client "github.com/semaphoreci/cli/api/client"
+	"github.com/semaphoreci/cli/cmd/utils"
+	"github.com/spf13/cobra"
+)
+
+type YamlBody struct {
+	YamlDefinition string `json:"yaml_definition"`
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate a pipeline yaml file",
+	Long:  "",
+	Run: func(cmd *cobra.Command, args []string) {
+		c := client.NewBaseClientFromConfig()
+
+		if len(args) != 1 {
+			fmt.Println("Usage: sem validate [PATH_TO_YAML_FILE]")
+			os.Exit(1)
+		}
+
+		fileContent, err := os.ReadFile(args[0])
+		utils.Check(err)
+
+		body := YamlBody{
+			YamlDefinition: string(fileContent),
+		}
+
+		json_body, err := json.Marshal(body)
+		utils.Check(err)
+
+		response, status, err := c.Post("yaml", json_body)
+		utils.Check(err)
+
+		if status == 200 {
+			fmt.Println("Valid!")
+		} else {
+			fmt.Println("Not valid!")
+		}
+		fmt.Println(string(response))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(validateCmd)
+}


### PR DESCRIPTION
I went looking in the cli for this feature and reached out to support, who pointed me at the [/v1alpha/yaml API docs](https://docs.semaphoreci.com/reference/api-v1alpha/#validating-a-pipeline-yaml)[^1] so I figured wrapping it in the cli would be useful as I keep trying to reach for it.

It's a painful feedback loop to copy/paste a `.semaphore/semaphore.yml` from one project to another and edit it, then remember there's some extra stuff from a second project you want to include, so you copy/paste that lot in. Then you push your changes and find a simple syntax error in the pipeline file. Being able to check that _before_ pushing, even though it is limited in what it can check is still super useful and being able to do it from your dev machine is a super tight feedback loop.

Initially I started trying to wedge this under `sem get pipeline validate FILE` as it's a pipeline related task. That's not where it lives in the API though, so I moved it to a top level command just now. `sem validate FILE`.

The output isn't great, it seems depending on whether it's parseable YAML or a schema error we can get back different error outputs. Following the lead of the UI, I'm just dumping the response back to the user with a quick note on :+1:/:-1: first.

[^1]: Thanks Noelia and Marko!