### PR TITLE
feat: add support for agent type name settings

### DIFF
--- a/api/client/agent_types_v1_alpha.go
+++ b/api/client/agent_types_v1_alpha.go
@@ -85,3 +85,22 @@ func (c *AgentTypeApiV1AlphaApi) CreateAgentType(d *models.AgentTypeV1Alpha) (*m
 
 	return models.NewAgentTypeV1AlphaFromJson(body)
 }
+
+func (c *AgentTypeApiV1AlphaApi) UpdateAgentType(d *models.AgentTypeV1Alpha) (*models.AgentTypeV1Alpha, error) {
+	json_body, err := d.ToJson()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failed to serialize object '%s'", err))
+	}
+
+	body, status, err := c.BaseClient.Patch(c.ResourceNamePlural, d.Metadata.Name, json_body)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("updating %s on Semaphore failed '%s'", c.ResourceNameSingular, err))
+	}
+
+	if status != 200 {
+		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
+	}
+
+	return models.NewAgentTypeV1AlphaFromJson(body)
+}

--- a/api/models/agent_type_list_v1_alpha.go
+++ b/api/models/agent_type_list_v1_alpha.go
@@ -20,7 +20,7 @@ func NewAgentTypeListV1AlphaFromJson(data []byte) (*AgentTypeListV1Alpha, error)
 		}
 
 		if s.Kind == "" {
-			s.Kind = "SelfHostedAgentType"
+			s.Kind = KindSelfHostedAgentType
 		}
 	}
 

--- a/api/models/agent_type_v1_alpha.go
+++ b/api/models/agent_type_v1_alpha.go
@@ -7,6 +7,13 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const KindSelfHostedAgentType = "SelfHostedAgentType"
+
+var SelfHostedAgentTypeAssignmentOrigins = []string{
+	"assignment_origin_agent",
+	"assignment_origin_aws_sts",
+}
+
 type AgentTypeV1Alpha struct {
 	ApiVersion string                   `json:"apiVersion,omitempty" yaml:"apiVersion"`
 	Kind       string                   `json:"kind,omitempty" yaml:"kind"`
@@ -79,11 +86,11 @@ func NewAgentTypeV1AlphaFromYaml(data []byte) (*AgentTypeV1Alpha, error) {
 
 func (s *AgentTypeV1Alpha) setApiVersionAndKind() {
 	s.ApiVersion = "v1alpha"
-	s.Kind = "SelfHostedAgentType"
+	s.Kind = KindSelfHostedAgentType
 }
 
 func (s *AgentTypeV1Alpha) ObjectName() string {
-	return fmt.Sprintf("SelfHostedAgentType/%s", s.Metadata.Name)
+	return fmt.Sprintf("%s/%s", KindSelfHostedAgentType, s.Metadata.Name)
 }
 
 func (s *AgentTypeV1Alpha) ToJson() ([]byte, error) {

--- a/api/models/agent_type_v1_alpha.go
+++ b/api/models/agent_type_v1_alpha.go
@@ -11,6 +11,7 @@ type AgentTypeV1Alpha struct {
 	ApiVersion string                   `json:"apiVersion,omitempty" yaml:"apiVersion"`
 	Kind       string                   `json:"kind,omitempty" yaml:"kind"`
 	Metadata   AgentTypeV1AlphaMetadata `json:"metadata" yaml:"metadata"`
+	Spec       AgentTypeV1AlphaSpec     `json:"spec" yaml:"spec"`
 	Status     AgentTypeV1AlphaStatus   `json:"status" yaml:"status"`
 }
 
@@ -18,6 +19,21 @@ type AgentTypeV1AlphaMetadata struct {
 	Name       string      `json:"name,omitempty" yaml:"name,omitempty"`
 	CreateTime json.Number `json:"create_time,omitempty" yaml:"create_time,omitempty"`
 	UpdateTime json.Number `json:"update_time,omitempty" yaml:"update_time,omitempty"`
+}
+
+type AgentTypeV1AlphaSpec struct {
+	AgentNameSettings AgentTypeV1AlphaAgentNameSettings `json:"agent_name_settings" yaml:"agent_name_settings"`
+}
+
+type AgentTypeV1AlphaAgentNameSettings struct {
+	AssignmentOrigin string              `json:"assignment_origin,omitempty" yaml:"assignment_origin,omitempty"`
+	Aws              AgentTypeV1AlphaAws `json:"aws,omitempty" yaml:"aws,omitempty"`
+	ReleaseAfter     int64               `json:"release_after" yaml:"release_after"`
+}
+
+type AgentTypeV1AlphaAws struct {
+	AccountID        string `json:"account_id,omitempty" yaml:"account_id,omitempty"`
+	RoleNamePatterns string `json:"role_name_patterns,omitempty" yaml:"role_name_patterns,omitempty"`
 }
 
 type AgentTypeV1AlphaStatus struct {
@@ -53,6 +69,11 @@ func NewAgentTypeV1AlphaFromYaml(data []byte) (*AgentTypeV1Alpha, error) {
 	}
 
 	a.setApiVersionAndKind()
+
+	if a.Spec.AgentNameSettings.AssignmentOrigin == "" {
+		a.Spec.AgentNameSettings.AssignmentOrigin = "assignment_origin_agent"
+	}
+
 	return &a, nil
 }
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -103,6 +103,15 @@ func RunApply(cmd *cobra.Command, args []string) {
 		utils.Check(err)
 
 		fmt.Printf("Project '%s' updated.\n", proj.Metadata.Name)
+	case "SelfHostedAgentType":
+		at, err := models.NewAgentTypeV1AlphaFromYaml(data)
+		utils.Check(err)
+
+		c := client.NewAgentTypeApiV1AlphaApi()
+		newAgentType, err := c.UpdateAgentType(at)
+		utils.Check(err)
+
+		fmt.Printf("SelfHostedAgentType '%s' updated.\n", newAgentType.Metadata.Name)
 	case models.DeploymentTargetKindV1Alpha:
 		target, err := models.NewDeploymentTargetV1AlphaFromYaml(data)
 		utils.Check(err)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -103,7 +103,7 @@ func RunApply(cmd *cobra.Command, args []string) {
 		utils.Check(err)
 
 		fmt.Printf("Project '%s' updated.\n", proj.Metadata.Name)
-	case "SelfHostedAgentType":
+	case models.KindSelfHostedAgentType:
 		at, err := models.NewAgentTypeV1AlphaFromYaml(data)
 		utils.Check(err)
 
@@ -111,7 +111,7 @@ func RunApply(cmd *cobra.Command, args []string) {
 		newAgentType, err := c.UpdateAgentType(at)
 		utils.Check(err)
 
-		fmt.Printf("SelfHostedAgentType '%s' updated.\n", newAgentType.Metadata.Name)
+		fmt.Printf("%s '%s' updated.\n", models.KindSelfHostedAgentType, newAgentType.Metadata.Name)
 	case models.DeploymentTargetKindV1Alpha:
 		target, err := models.NewDeploymentTargetV1AlphaFromYaml(data)
 		utils.Check(err)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -191,17 +191,15 @@ var CreateAgentTypeCmd = &cobra.Command{
 			ReleaseAfter:     releaseNameAfter,
 		}
 
-		if nameAssignmentOrigin == "assignment_origin_aws_sts" {
-			accountID, err := cmd.Flags().GetString("aws-account-id")
-			utils.Check(err)
+		accountID, err := cmd.Flags().GetString("aws-account-id")
+		utils.Check(err)
 
-			roles, err := cmd.Flags().GetString("aws-roles")
-			utils.Check(err)
+		roles, err := cmd.Flags().GetString("aws-roles")
+		utils.Check(err)
 
-			at.Spec.AgentNameSettings.Aws = models.AgentTypeV1AlphaAws{
-				AccountID:        accountID,
-				RoleNamePatterns: roles,
-			}
+		at.Spec.AgentNameSettings.Aws = models.AgentTypeV1AlphaAws{
+			AccountID:        accountID,
+			RoleNamePatterns: roles,
 		}
 
 		agentType, err := c.CreateAgentType(&at)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -286,7 +286,7 @@ func init() {
 	CreateWorkflowCmd.Flags().BoolP("follow", "f", false,
 		"run 'get ppl <ppl_id>' after create repeatedly until pipeline reaches terminal state")
 
-	CreateAgentTypeCmd.Flags().StringP("name-assignment-origin", "o", "assignment_origin_agent", "name assignment origin: Possible values: [assignment_origin_agent, assignment_origin_aws_sts]")
+	CreateAgentTypeCmd.Flags().StringP("name-assignment-origin", "o", "assignment_origin_agent", "from where agents will get their names when they register. Possible values: [assignment_origin_agent, assignment_origin_aws_sts]")
 	CreateAgentTypeCmd.Flags().Int64P("release-name-after", "r", 0, "how long to hold the agent name after disconnection, in seconds; if not specified, 0 is used.")
 	CreateAgentTypeCmd.Flags().String("aws-account-id", "", "required if -o AWS_STS is used; AWS account ID to allow registrations")
 	CreateAgentTypeCmd.Flags().String("aws-roles", "", "required if -o AWS_STS is used; comma-separated list of AWS role names")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/semaphoreci/cli/cmd/utils"
 	"github.com/semaphoreci/cli/cmd/workflows"
@@ -106,7 +107,7 @@ var createCmd = &cobra.Command{
 			utils.Check(err)
 
 			fmt.Printf("Job '%s' created.\n", job.Metadata.Id)
-		case "SelfHostedAgentType":
+		case models.KindSelfHostedAgentType:
 			at, err := models.NewAgentTypeV1AlphaFromYaml(data)
 			utils.Check(err)
 
@@ -174,6 +175,11 @@ var CreateAgentTypeCmd = &cobra.Command{
 
 		nameAssignmentOrigin, err := cmd.Flags().GetString("name-assignment-origin")
 		utils.Check(err)
+
+		if !utils.Contains(models.SelfHostedAgentTypeAssignmentOrigins, nameAssignmentOrigin) {
+			fmt.Printf("invalid name assignment origin '%s'\n", nameAssignmentOrigin)
+			os.Exit(1)
+		}
 
 		releaseNameAfter, err := cmd.Flags().GetInt64("release-name-after")
 		utils.Check(err)
@@ -286,7 +292,13 @@ func init() {
 	CreateWorkflowCmd.Flags().BoolP("follow", "f", false,
 		"run 'get ppl <ppl_id>' after create repeatedly until pipeline reaches terminal state")
 
-	CreateAgentTypeCmd.Flags().StringP("name-assignment-origin", "o", "assignment_origin_agent", "from where agents will get their names when they register. Possible values: [assignment_origin_agent, assignment_origin_aws_sts]")
+	CreateAgentTypeCmd.Flags().StringP(
+		"name-assignment-origin",
+		"o",
+		models.SelfHostedAgentTypeAssignmentOrigins[0],
+		fmt.Sprintf("from where agents will get their names when they register. Possible values: %v", models.SelfHostedAgentTypeAssignmentOrigins),
+	)
+
 	CreateAgentTypeCmd.Flags().Int64P("release-name-after", "r", 0, "how long to hold the agent name after disconnection, in seconds; if not specified, 0 is used.")
 	CreateAgentTypeCmd.Flags().String("aws-account-id", "", "required if -o AWS_STS is used; AWS account ID to allow registrations")
 	CreateAgentTypeCmd.Flags().String("aws-roles", "", "required if -o AWS_STS is used; comma-separated list of AWS role names")

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -231,7 +231,51 @@ metadata:
 	RootCmd.SetArgs([]string{"create", "-f", yaml_file_path})
 	RootCmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing-from-yaml"},"status":{}}`
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing-from-yaml"},"spec":{"agent_name_settings":{"assignment_origin":"assignment_origin_agent","aws":{},"release_after":0}},"status":{}}`
+
+	if received != expected {
+		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)
+	}
+}
+
+func Test__CreateAgentType__FromYamlWithSettings__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	yaml_file := `
+apiVersion: v1alpha
+kind: SelfHostedAgentType
+metadata:
+  name: s1-testing-from-yaml
+spec:
+  agent_name_settings:
+    assignment_origin: assignment_origin_aws_sts
+    release_after: 60
+    aws:
+      account_id: "1234567890"
+      role_name_patterns: role1,role2
+`
+
+	yaml_file_path := "/tmp/agent_type.yaml"
+
+	ioutil.WriteFile(yaml_file_path, []byte(yaml_file), 0644)
+
+	received := ""
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, received), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"create", "-f", yaml_file_path})
+	RootCmd.Execute()
+
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing-from-yaml"},"spec":{"agent_name_settings":{"assignment_origin":"assignment_origin_aws_sts","aws":{"account_id":"1234567890","role_name_patterns":"role1,role2"},"release_after":60}},"status":{}}`
 
 	if received != expected {
 		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)
@@ -257,7 +301,42 @@ func Test__CreateAgentType__Response200(t *testing.T) {
 	RootCmd.SetArgs([]string{"create", "agent_type", "s1-testing"})
 	RootCmd.Execute()
 
-	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing"},"status":{}}`
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing"},"spec":{"agent_name_settings":{"assignment_origin":"assignment_origin_agent","aws":{},"release_after":0}},"status":{}}`
+
+	if received != expected {
+		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)
+	}
+}
+
+func Test__CreateAgentTypeWithSettings__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := ""
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/self_hosted_agent_types",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, received), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{
+		"create",
+		"agent_type",
+		"s1-testing",
+		"-o", "assignment_origin_aws_sts",
+		"-r", "60",
+		"--aws-account-id", "1234567890",
+		"--aws-roles", "role1,role2",
+	})
+
+	RootCmd.Execute()
+
+	expected := `{"apiVersion":"v1alpha","kind":"SelfHostedAgentType","metadata":{"name":"s1-testing"},"spec":{"agent_name_settings":{"assignment_origin":"assignment_origin_aws_sts","aws":{"account_id":"1234567890","role_name_patterns":"role1,role2"},"release_after":60}},"status":{}}`
 
 	if received != expected {
 		t.Errorf("Expected the API to receive POST self_hosted_agent_types with: %s, got: %s", expected, received)

--- a/cmd/utils/slices.go
+++ b/cmd/utils/slices.go
@@ -1,0 +1,11 @@
+package utils
+
+func Contains(slice []string, item string) bool {
+	for _, i := range slice {
+		if i == item {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/utils/slices_test.go
+++ b/cmd/utils/slices_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	require "github.com/stretchr/testify/require"
+)
+
+func Test__Contains(t *testing.T) {
+	require.False(t, Contains([]string{}, "a"))
+	require.False(t, Contains([]string{"a", "b", "c"}, "d"))
+	require.True(t, Contains([]string{"a", "b", "c"}, "a"))
+}


### PR DESCRIPTION
This pull request adds a spec field to the agent type model. For now, the spec will only contain an `agent_name_settings` field, with the following properties:
- `assignment_origin`: a string to specify if agents will have their names assigned by AWS STS (`assignment_origin_aws_sts`) or by themselves (`assignment_origin_agent`). The default is `assignment_origin_agent`.
- `release_after`: number of seconds to hold the agent name after its disconnection. By default, this is 0.
- `aws`: an object field to specify the `account_id` and `role_name_patterns` when `assignment_origin_aws_sts` is used.

Here's an example of an agent type with `assignment_origin_agent`:

```yaml
apiVersion: v1alpha
kind: SelfHostedAgentType
metadata:
  name: s1-testing
  create_time: 1700679079
  update_time: 1700679079
spec:
  agent_name_settings:
    assignment_origin: assignment_origin_agent
    release_after: 0
```

And here's an example of a `assignment_origin_aws_sts` agent type:

```yaml
apiVersion: v1alpha
kind: SelfHostedAgentType
metadata:
  name: s1-aws-only
  create_time: 1699034152
  update_time: 1699038879
spec:
  agent_name_settings:
    assignment_origin: assignment_origin_aws_sts
    aws:
      account_id: "1234567890"
      role_name_patterns: role1,role2
    release_after: 0
```

### Changes in commands

1. The `create` command changed to include four new flags:

```
      --aws-account-id string           required if -o AWS_STS is used; AWS account ID to allow registrations
      --aws-roles string                required if -o AWS_STS is used; comma-separated list of AWS role names
  -o, --name-assignment-origin string   from where agents will get their names when they register. Possible values: [assignment_origin_agent, assignment_origin_aws_sts] (default "assignment_origin_agent")
  -r, --release-name-after int          how long to hold the agent name after disconnection, in seconds; if not specified, 0 is used.
```

2. Support for the `SelfHostedAgentType` type was added to the `apply` command.
3. The `get` command command was updated to reflect the changes in the agent type model.