### PR TITLE
Add project secret create to sem create secret

### DIFF
--- a/cmd/create_secret.go
+++ b/cmd/create_secret.go
@@ -38,6 +38,7 @@ func NewCreateSecretCmd() *cobra.Command {
 		"project name; if specified will edit project level secret, otherwise organization secret")
 	cmd.Flags().StringP("project-id", "i", "",
 		"project id; if specified will edit project level secret, otherwise organization secret")
+	cmd.MarkFlagsMutuallyExclusive("project-name", "project-id")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		projectID := GetProjectID(cmd)

--- a/cmd/create_secret.go
+++ b/cmd/create_secret.go
@@ -15,7 +15,7 @@ func NewCreateSecretCmd() *cobra.Command {
 	cmd := &cobra.Command{}
 
 	cmd.Use = "secret [NAME]"
-	cmd.Short = "Create a secret."
+	cmd.Short = "Create a secret. If project is specified (via -p or -i), create a project secret."
 	cmd.Long = ``
 	cmd.Aliases = []string{"secrets"}
 	cmd.Args = cobra.ExactArgs(1)
@@ -34,59 +34,133 @@ func NewCreateSecretCmd() *cobra.Command {
 		"Environment Variables",
 	)
 
+	cmd.Flags().StringP("project-name", "p", "",
+		"project name; if specified will edit project level secret, otherwise organization secret")
+	cmd.Flags().StringP("project-id", "i", "",
+		"project id; if specified will edit project level secret, otherwise organization secret")
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		projectID := GetProjectID(cmd)
+
 		name := args[0]
 
 		fileFlags, err := cmd.Flags().GetStringArray("file")
 		utils.Check(err)
-
-		var files []models.SecretV1BetaFile
-		for _, fileFlag := range fileFlags {
-			matchFormat, err := regexp.MatchString(`^[^: ]+:[^: ]+$`, fileFlag)
-			utils.Check(err)
-
-			if !matchFormat {
-				utils.Fail("The format of --file flag must be: <local-path>:<semaphore-path>")
-			}
-
-			flagPaths := strings.Split(fileFlag, ":")
-
-			file := models.SecretV1BetaFile{}
-			file.Path = flagPaths[1]
-			file.Content = encodeFromFileAt(flagPaths[0])
-			files = append(files, file)
-		}
-
 		envFlags, err := cmd.Flags().GetStringArray("env")
 		utils.Check(err)
 
-		var envVars []models.SecretV1BetaEnvVar
-		for _, envFlag := range envFlags {
-			matchFormat, err := regexp.MatchString(`^.+=.+$`, envFlag)
+		if projectID == "" {
+			files := parseSecretFiles(fileFlags)
+			envVars := parseSecretEnvVars(envFlags)
+
+			secret := models.NewSecretV1Beta(name, envVars, files)
+
+			c := client.NewSecretV1BetaApi()
+
+			_, err = c.CreateSecret(&secret)
+
 			utils.Check(err)
 
-			if !matchFormat {
-				utils.Fail("The format of -e flag must be: <NAME>=<VALUE>")
-			}
+			fmt.Printf("Secret '%s' created.\n", secret.Metadata.Name)
+		} else {
+			files := parseProjectSecretFiles(fileFlags)
+			envVars := parseProjectSecretEnvVars(envFlags)
 
-			parts := strings.SplitN(envFlag, "=", 2)
+			secret := models.NewProjectSecretV1(name, envVars, files)
 
-			envVars = append(envVars, models.SecretV1BetaEnvVar{
-				Name:  parts[0],
-				Value: parts[1],
-			})
+			c := client.NewProjectSecretV1Api(projectID)
+
+			_, err = c.CreateSecret(&secret)
+
+			utils.Check(err)
+
+			fmt.Printf("Project secret '%s' created.\n", secret.Metadata.Name)
 		}
-
-		secret := models.NewSecretV1Beta(name, envVars, files)
-
-		c := client.NewSecretV1BetaApi()
-
-		_, err = c.CreateSecret(&secret)
-
-		utils.Check(err)
-
-		fmt.Printf("Secret '%s' created.\n", secret.Metadata.Name)
 	}
 
 	return cmd
+}
+
+func parseProjectSecretFiles(fileFlags []string) []models.ProjectSecretV1File {
+	var files []models.ProjectSecretV1File
+
+	for _, fileFlag := range fileFlags {
+		p, c := parseFile(fileFlag)
+
+		var file models.ProjectSecretV1File
+		file.Path = p
+		file.Content = encodeFromFileAt(c)
+		files = append(files, file)
+	}
+	return files
+}
+
+func parseSecretFiles(fileFlags []string) []models.SecretV1BetaFile {
+	var files []models.SecretV1BetaFile
+
+	for _, fileFlag := range fileFlags {
+		p, c := parseFile(fileFlag)
+
+		var file models.SecretV1BetaFile
+		file.Path = p
+		file.Content = encodeFromFileAt(c)
+		files = append(files, file)
+	}
+	return files
+}
+
+func parseFile(fileFlag string) (path, content string) {
+	matchFormat, err := regexp.MatchString(`^[^: ]+:[^: ]+$`, fileFlag)
+	utils.Check(err)
+
+	if !matchFormat {
+		utils.Fail("The format of --file flag must be: <local-path>:<semaphore-path>")
+	}
+
+	flagPaths := strings.Split(fileFlag, ":")
+
+	return flagPaths[1], flagPaths[0]
+}
+
+func parseProjectSecretEnvVars(envFlags []string) []models.ProjectSecretV1EnvVar {
+	var envVars []models.ProjectSecretV1EnvVar
+
+	for _, envFlag := range envFlags {
+		n, v := parseEnvVar(envFlag)
+
+		var envVar models.ProjectSecretV1EnvVar
+		envVar.Name = n
+		envVar.Value = v
+		envVars = append(envVars, envVar)
+	}
+
+	return envVars
+}
+
+func parseSecretEnvVars(envFlags []string) []models.SecretV1BetaEnvVar {
+	var envVars []models.SecretV1BetaEnvVar
+
+	for _, envFlag := range envFlags {
+		n, v := parseEnvVar(envFlag)
+
+		var envVar models.SecretV1BetaEnvVar
+		envVar.Name = n
+		envVar.Value = v
+		envVars = append(envVars, envVar)
+	}
+
+	return envVars
+}
+
+func parseEnvVar(envFlag string) (name, value string) {
+	matchFormat, err := regexp.MatchString(`^.+=.+$`, envFlag)
+	utils.Check(err)
+
+	if !matchFormat {
+		utils.Fail("The format of -e flag must be: <NAME>=<VALUE>")
+	}
+
+	parts := strings.SplitN(envFlag, "=", 2)
+
+	return parts[0], parts[1]
 }

--- a/cmd/create_secret_test.go
+++ b/cmd/create_secret_test.go
@@ -52,3 +52,59 @@ func Test__CreateSecret__WithSubcommand__Response200(t *testing.T) {
 
 	assert.Equal(t, received, expected)
 }
+
+func Test__CreateSecret__WithProjectID__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := ""
+
+	dash := `{
+		"metadata":{
+			"name":"hello",
+			"id":"bb2ba294-d4b3-48bc-90a7-12dd56e9424b",
+		}
+	}`
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects/hello",
+		func(req *http.Request) (*http.Response, error) {
+			fmt.Println("GET /api/v1alpha/projects/hello")
+			return httpmock.NewStringResponse(200, dash), nil
+		},
+	)
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1/projects/hello/secrets",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+
+			received = string(body)
+
+			return httpmock.NewStringResponse(200, received), nil
+		},
+	)
+
+	content1 := "This is some docker config"
+	content2 := "This is some gcloud config"
+
+	ioutil.WriteFile("/tmp/docker", []byte(content1), 0644)
+	ioutil.WriteFile("/tmp/gcloud", []byte(content2), 0644)
+
+	// flags for env vars and projects stay the same as in the previous test
+
+	RootCmd.SetArgs([]string{
+		"create",
+		"secret",
+		"-i", "hello",
+		"projectABC",
+	})
+
+
+	RootCmd.Execute()
+
+	
+	file1 := base64.StdEncoding.EncodeToString([]byte(content1))
+	file2 := base64.StdEncoding.EncodeToString([]byte(content2))	// We do not expect project_id_or_name to be received in the body of the request, as it's set by the grpc-gateway from the URL
+	expected := fmt.Sprintf(`{"apiVersion":"v1","kind":"ProjectSecret","metadata":{"name":"projectABC"},"data":{"env_vars":[{"name":"FOO","value":"BAR"},{"name":"ZEZ","value":"Hello World"}],"files":[{"path":".config/docker","content":"%s"},{"path":".config/gcloud","content":"%s"}]}}`, file1, file2)
+
+	assert.Equal(t, expected, received)
+}


### PR DESCRIPTION
Allows users to create a project level secret with `sem create secret` by specifying `-p` or `-i` flags with project ID or Name. The file and env var parsing is separated into two functions as it is the simples approach.