### PR TITLE
Handle secrets without contents

### DIFF
--- a/api/client/project_secrets_v1.go
+++ b/api/client/project_secrets_v1.go
@@ -109,17 +109,21 @@ func (c *ProjectSecretsApiV1Api) UpdateSecret(d *models.ProjectSecretV1) (*model
 	}
 
 	if status != 200 {
-		fallbackResponse, err := c.fallbackUpdate(identifier, d)
-		if err != nil {
 		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
-		}
-		return fallbackResponse, nil
 	}
 
 	return models.NewProjectSecretV1FromJson(body)
 }
 
-func (c *ProjectSecretsApiV1Api) fallbackUpdate(identifier string, d *models.ProjectSecretV1) (*models.ProjectSecretV1, error) {
+func (c *ProjectSecretsApiV1Api) FallbackUpdate(d *models.ProjectSecretV1) (*models.ProjectSecretV1, error) {
+	identifier := ""
+
+	if d.Metadata.Id != "" {
+		identifier = d.Metadata.Id
+	} else {
+		identifier = d.Metadata.Name
+	}
+
 	err := c.DeleteSecret(identifier)
 
 	if err != nil {

--- a/api/client/secrets_v1_beta.go
+++ b/api/client/secrets_v1_beta.go
@@ -111,18 +111,21 @@ func (c *SecretApiV1BetaApi) UpdateSecret(d *models.SecretV1Beta) (*models.Secre
 	}
 
 	if status != 200 {
-		fallbackResponse, err := c.fallbackUpdate(identifier, d)
-		if err != nil {
-			return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
-
-		}
-		return fallbackResponse, nil
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
 	}
 
 	return models.NewSecretV1BetaFromJson(body)
 }
 
-func (c *SecretApiV1BetaApi) fallbackUpdate(identifier string, d *models.SecretV1Beta) (*models.SecretV1Beta, error) {
+func (c *SecretApiV1BetaApi) FallbackUpdate(d *models.SecretV1Beta) (*models.SecretV1Beta, error) {
+	identifier := ""
+
+	if d.Metadata.Id != "" {
+		identifier = d.Metadata.Id
+	} else {
+		identifier = d.Metadata.Name
+	}
+
 	err := c.DeleteSecret(identifier)
 
 	if err != nil {

--- a/api/client/secrets_v1_beta.go
+++ b/api/client/secrets_v1_beta.go
@@ -102,8 +102,6 @@ func (c *SecretApiV1BetaApi) UpdateSecret(d *models.SecretV1Beta) (*models.Secre
 		identifier = d.Metadata.Name
 	}
 
-	fmt.Printf("This might overwrite the secret '%s' and change it's id.", identifier)
-
 	body, status, err := c.BaseClient.Patch(c.ResourceNamePlural, identifier, json_body)
 
 	if err != nil {

--- a/api/models/project_secret_v1.go
+++ b/api/models/project_secret_v1.go
@@ -17,12 +17,12 @@ type ProjectSecretV1 struct {
 
 type ProjectSecretV1EnvVar struct {
 	Name  string `json:"name" yaml:"name"`
-	Value string `json:"value" yaml:"value"`
+	Value string `json:"value" yaml:"value,omitempty"`
 }
 
 type ProjectSecretV1File struct {
 	Path    string `json:"path" yaml:"path"`
-	Content string `json:"content" yaml:"content"`
+	Content string `json:"content" yaml:"content,omitempty"`
 }
 
 type ProjectSecretV1Data struct {

--- a/api/models/project_secret_v1.go
+++ b/api/models/project_secret_v1.go
@@ -36,7 +36,7 @@ type ProjectSecretV1Metadata struct {
 	CreateTime      json.Number `json:"create_time,omitempty,string" yaml:"create_time,omitempty"`
 	UpdateTime      json.Number `json:"update_time,omitempty,string" yaml:"update_time,omitempty"`
 	ProjectIdOrName string      `json:"project_id_or_name,omitempty" yaml:"project_id_or_name,omitempty"`
-	ContentIncluded bool        `json:"content_included,omitempty" yaml:"content_included,omitempty"`
+	ContentIncluded bool        `json:"content_included,omitempty" yaml:"content_included"`
 }
 
 func NewProjectSecretV1(name string, envVars []ProjectSecretV1EnvVar, files []ProjectSecretV1File) ProjectSecretV1 {
@@ -96,19 +96,5 @@ func (s *ProjectSecretV1) ToJson() ([]byte, error) {
 }
 
 func (s *ProjectSecretV1) ToYaml() ([]byte, error) {
-	if !s.Metadata.ContentIncluded {
-		notice := []byte(`
-# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
-# Note: You can exit without saving to skip.
-
-`)
-
-		s, err := yaml.Marshal(s)
-		if err != nil {
-			return nil, err
-		}
-		return append(notice, s...), nil
-
-	}
 	return yaml.Marshal(s)
 }

--- a/api/models/project_secret_v1.go
+++ b/api/models/project_secret_v1.go
@@ -97,7 +97,12 @@ func (s *ProjectSecretV1) ToJson() ([]byte, error) {
 
 func (s *ProjectSecretV1) ToYaml() ([]byte, error) {
 	if !s.Metadata.ContentIncluded {
-		notice := []byte("# Note: Environment variables and file contents are hidden and accessible only in jobs\n\n")
+		notice := []byte(`
+# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# Note: You can exit without saving to skip.
+
+`)
+
 		s, err := yaml.Marshal(s)
 		if err != nil {
 			return nil, err

--- a/api/models/secret_v1_beta.go
+++ b/api/models/secret_v1_beta.go
@@ -36,7 +36,7 @@ type SecretV1BetaMetadata struct {
 	Id              string      `json:"id,omitempty" yaml:"id,omitempty"`
 	CreateTime      json.Number `json:"create_time,omitempty,string" yaml:"create_time,omitempty"`
 	UpdateTime      json.Number `json:"update_time,omitempty,string" yaml:"update_time,omitempty"`
-	ContentIncluded bool        `json:"content_included,omitempty" yaml:"content_included,omitempty"`
+	ContentIncluded bool        `json:"content_included,omitempty" yaml:"content_included"`
 }
 
 type SecretV1BetaOrgConfig struct {
@@ -103,19 +103,5 @@ func (s *SecretV1Beta) ToJson() ([]byte, error) {
 }
 
 func (s *SecretV1Beta) ToYaml() ([]byte, error) {
-	if !s.Metadata.ContentIncluded {
-		notice := []byte(`
-# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
-# Note: You can exit without saving to skip.
-
-`)
-
-		s, err := yaml.Marshal(s)
-		if err != nil {
-			return nil, err
-		}
-		return append(notice, s...), nil
-
-	}
 	return yaml.Marshal(s)
 }

--- a/api/models/secret_v1_beta.go
+++ b/api/models/secret_v1_beta.go
@@ -32,10 +32,11 @@ type SecretV1BetaData struct {
 }
 
 type SecretV1BetaMetadata struct {
-	Name       string      `json:"name,omitempty" yaml:"name,omitempty"`
-	Id         string      `json:"id,omitempty" yaml:"id,omitempty"`
-	CreateTime json.Number `json:"create_time,omitempty,string" yaml:"create_time,omitempty"`
-	UpdateTime json.Number `json:"update_time,omitempty,string" yaml:"update_time,omitempty"`
+	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
+	Id              string      `json:"id,omitempty" yaml:"id,omitempty"`
+	CreateTime      json.Number `json:"create_time,omitempty,string" yaml:"create_time,omitempty"`
+	UpdateTime      json.Number `json:"update_time,omitempty,string" yaml:"update_time,omitempty"`
+	ContentIncluded bool        `json:"content_included,omitempty" yaml:"content_included,omitempty"`
 }
 
 type SecretV1BetaOrgConfig struct {
@@ -93,10 +94,23 @@ func (s *SecretV1Beta) ObjectName() string {
 	return fmt.Sprintf("Secrets/%s", s.Metadata.Name)
 }
 
+func (s *SecretV1Beta) Editable() bool {
+	return s.Metadata.ContentIncluded
+}
+
 func (s *SecretV1Beta) ToJson() ([]byte, error) {
 	return json.Marshal(s)
 }
 
 func (s *SecretV1Beta) ToYaml() ([]byte, error) {
+	if !s.Metadata.ContentIncluded {
+		notice := []byte("# Note: Environment variables and file contents are hidden and accessible only in jobs\n\n") 
+		s, err := yaml.Marshal(s)
+		if err != nil {
+			return nil, err
+		}
+		return append(notice, s...), nil
+
+	}
 	return yaml.Marshal(s)
 }

--- a/api/models/secret_v1_beta.go
+++ b/api/models/secret_v1_beta.go
@@ -104,7 +104,12 @@ func (s *SecretV1Beta) ToJson() ([]byte, error) {
 
 func (s *SecretV1Beta) ToYaml() ([]byte, error) {
 	if !s.Metadata.ContentIncluded {
-		notice := []byte("# Note: Environment variables and file contents are hidden and accessible only in jobs\n\n") 
+		notice := []byte(`
+# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# Note: You can exit without saving to skip.
+
+`)
+
 		s, err := yaml.Marshal(s)
 		if err != nil {
 			return nil, err

--- a/api/models/secret_v1_beta.go
+++ b/api/models/secret_v1_beta.go
@@ -18,12 +18,12 @@ type SecretV1Beta struct {
 
 type SecretV1BetaEnvVar struct {
 	Name  string `json:"name" yaml:"name"`
-	Value string `json:"value" yaml:"value"`
+	Value string `json:"value" yaml:"value,omitempty"`
 }
 
 type SecretV1BetaFile struct {
 	Path    string `json:"path" yaml:"path"`
-	Content string `json:"content" yaml:"content"`
+	Content string `json:"content" yaml:"content,omitempty"`
 }
 
 type SecretV1BetaData struct {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -50,7 +50,15 @@ func RunApply(cmd *cobra.Command, args []string) {
 
 		c := client.NewSecretV1BetaApi()
 
-		secret, err = c.UpdateSecret(secret)
+		if secret.Editable() {
+			secret, err = c.UpdateSecret(secret)
+		} else {
+			cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+			err = utils.Ask(secret.Metadata.Name)
+			if err == nil {
+				secret, err = c.FallbackUpdate(secret)
+			}
+		}
 
 		utils.Check(err)
 
@@ -62,7 +70,15 @@ func RunApply(cmd *cobra.Command, args []string) {
 
 		c := client.NewProjectSecretV1Api(secret.Metadata.ProjectIdOrName)
 
-		secret, err = c.UpdateSecret(secret)
+		if secret.Editable() {
+			secret, err = c.UpdateSecret(secret)
+		} else {
+			cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+			err = utils.Ask(secret.Metadata.Name)
+			if err == nil {
+				secret, err = c.FallbackUpdate(secret)
+			}
+		}
 
 		utils.Check(err)
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -53,7 +53,7 @@ func RunApply(cmd *cobra.Command, args []string) {
 		if secret.Editable() {
 			secret, err = c.UpdateSecret(secret)
 		} else {
-			cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+			cmd.Println(secretAskConfirmationMessage)
 			err = utils.Ask(secret.Metadata.Name)
 			if err == nil {
 				secret, err = c.FallbackUpdate(secret)
@@ -73,7 +73,7 @@ func RunApply(cmd *cobra.Command, args []string) {
 		if secret.Editable() {
 			secret, err = c.UpdateSecret(secret)
 		} else {
-			cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+			cmd.Println(secretAskConfirmationMessage)
 			err = utils.Ask(secret.Metadata.Name)
 			if err == nil {
 				secret, err = c.FallbackUpdate(secret)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -12,7 +12,7 @@ import (
 )
 
 const secretEditDangerMessage = `
- DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
 # Note: You can exit without saving to skip.
 
 `

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -94,7 +94,7 @@ var EditSecretCmd = &cobra.Command{
 	Short:   "Edit a secret.",
 	Long:    ``,
 	Aliases: []string{"secrets"},
-	Args: cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
 		projectID := GetProjectID(cmd)
@@ -106,11 +106,20 @@ var EditSecretCmd = &cobra.Command{
 
 			secret, err := c.GetSecret(name)
 
-			utils.Check(err)	
+			utils.Check(err)
 
 			content, err := secret.ToYaml()
 
 			utils.Check(err)
+
+			if !secret.Editable() {
+				notice := []byte(`
+# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# Note: You can exit without saving to skip.
+			
+			`)
+				content = append(notice, content...)
+			}
 
 			new_content, err := utils.EditYamlInEditor(secret.ObjectName(), string(content))
 
@@ -124,7 +133,7 @@ var EditSecretCmd = &cobra.Command{
 				secret, err = c.UpdateSecret(updated_secret)
 			} else {
 				cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
-				err = utils.Ask(secret.Metadata.Name)				
+				err = utils.Ask(secret.Metadata.Name)
 				if err == nil {
 					secret, err = c.FallbackUpdate(updated_secret)
 				}
@@ -145,6 +154,15 @@ var EditSecretCmd = &cobra.Command{
 			content, err := secret.ToYaml()
 
 			utils.Check(err)
+
+			if !secret.Editable() {
+				notice := []byte(`
+# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# Note: You can exit without saving to skip.
+			
+			`)
+				content = append(notice, content...)
+			}
 
 			new_content, err := utils.EditYamlInEditor(secret.ObjectName(), string(content))
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -94,7 +94,7 @@ var EditSecretCmd = &cobra.Command{
 	Short:   "Edit a secret.",
 	Long:    ``,
 	Aliases: []string{"secrets"},
-	Args:    cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(1),
 
 	Run: func(cmd *cobra.Command, args []string) {
 		projectID := GetProjectID(cmd)
@@ -106,7 +106,7 @@ var EditSecretCmd = &cobra.Command{
 
 			secret, err := c.GetSecret(name)
 
-			utils.Check(err)
+			utils.Check(err)	
 
 			content, err := secret.ToYaml()
 
@@ -120,7 +120,15 @@ var EditSecretCmd = &cobra.Command{
 
 			utils.Check(err)
 
-			secret, err = c.UpdateSecret(updated_secret)
+			if secret.Editable() {
+				secret, err = c.UpdateSecret(updated_secret)
+			} else {
+				cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+				err = utils.Ask(secret.Metadata.Name)				
+				if err == nil {
+					secret, err = c.FallbackUpdate(updated_secret)
+				}
+			}
 
 			utils.Check(err)
 
@@ -146,8 +154,15 @@ var EditSecretCmd = &cobra.Command{
 
 			utils.Check(err)
 
-			secret, err = c.UpdateSecret(updated_secret)
-
+			if secret.Editable() {
+				secret, err = c.UpdateSecret(updated_secret)
+			} else {
+				cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+				err = utils.Ask(secret.Metadata.Name)
+				if err == nil {
+					secret, err = c.FallbackUpdate(updated_secret)
+				}
+			}
 			utils.Check(err)
 
 			fmt.Printf("Secret '%s' updated.\n", secret.Metadata.Name)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -11,6 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const secretEditDangerMessage = `
+ DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
+# Note: You can exit without saving to skip.
+
+`
+const secretAskConfirmationMessage = `WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:`
+
 var editCmd = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit a resource from.",
@@ -113,11 +120,7 @@ var EditSecretCmd = &cobra.Command{
 			utils.Check(err)
 
 			if !secret.Editable() {
-				notice := []byte(`
-# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
-# Note: You can exit without saving to skip.
-			
-			`)
+				notice := []byte(secretEditDangerMessage)
 				content = append(notice, content...)
 			}
 
@@ -132,7 +135,7 @@ var EditSecretCmd = &cobra.Command{
 			if secret.Editable() {
 				secret, err = c.UpdateSecret(updated_secret)
 			} else {
-				cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+				cmd.Println(secretAskConfirmationMessage)
 				err = utils.Ask(secret.Metadata.Name)
 				if err == nil {
 					secret, err = c.FallbackUpdate(updated_secret)
@@ -156,11 +159,7 @@ var EditSecretCmd = &cobra.Command{
 			utils.Check(err)
 
 			if !secret.Editable() {
-				notice := []byte(`
-# DANGER! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
-# Note: You can exit without saving to skip.
-			
-			`)
+				notice := []byte(secretEditDangerMessage)
 				content = append(notice, content...)
 			}
 
@@ -175,7 +174,7 @@ var EditSecretCmd = &cobra.Command{
 			if secret.Editable() {
 				secret, err = c.UpdateSecret(updated_secret)
 			} else {
-				cmd.Println("WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever. To continue, please type in the (current) secret name:")
+				cmd.Println(secretAskConfirmationMessage)
 				err = utils.Ask(secret.Metadata.Name)
 				if err == nil {
 					secret, err = c.FallbackUpdate(updated_secret)

--- a/cmd/utils/ask_confirm.go
+++ b/cmd/utils/ask_confirm.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+)
+
+func Ask(name string) error {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		s, _ := reader.ReadString('\n')
+		s = strings.TrimSuffix(s, "\n")
+		s = strings.ToLower(s)
+		if strings.Compare(s, name) == 0 {
+			break
+		} else {
+			return errors.New("user did not confirm")
+		}
+	}
+	return nil
+}

--- a/cmd/utils/ask_confirm.go
+++ b/cmd/utils/ask_confirm.go
@@ -16,7 +16,7 @@ func Ask(name string) error {
 		if strings.Compare(s, name) == 0 {
 			break
 		} else {
-			return errors.New("user did not confirm")
+			return errors.New("user confirmation failed")
 		}
 	}
 	return nil


### PR DESCRIPTION
- Show secrets without contents nicely
- If update fails (which will happen when secret's contents can not be fetched) the cli will remove existing secret and recreate it with new contents.

task: https://github.com/renderedtext/project-tasks/issues/1284