### PR TITLE
fix: use new logs endpoint

### DIFF
--- a/api/client/logs_v1_alpha.go
+++ b/api/client/logs_v1_alpha.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+
+	models "github.com/semaphoreci/cli/api/models"
+)
+
+type LogsApiV1AlphaApi struct {
+	BaseClient           BaseClient
+	ResourceNameSingular string
+	ResourceNamePlural   string
+}
+
+func NewLogsV1AlphaApi() LogsApiV1AlphaApi {
+	baseClient := NewBaseClientFromConfig()
+	baseClient.SetApiVersion("v1alpha")
+
+	return LogsApiV1AlphaApi{
+		BaseClient:           baseClient,
+		ResourceNamePlural:   "logs",
+		ResourceNameSingular: "logs",
+	}
+}
+
+func (c *LogsApiV1AlphaApi) Get(jobID string) (*models.LogsV1Alpha, error) {
+	body, status, err := c.BaseClient.Get(c.ResourceNamePlural, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)
+	}
+
+	if status != 200 {
+		return nil, fmt.Errorf("http status %d with message \"%s\" received from upstream", status, body)
+	}
+
+	return models.NewLogsV1AlphaFromJson(body)
+}

--- a/api/models/logs_v1_alpha.go
+++ b/api/models/logs_v1_alpha.go
@@ -1,0 +1,26 @@
+package models
+
+import "encoding/json"
+
+type LogsV1Alpha struct {
+	Events []Event `json:"events"`
+}
+
+type Event struct {
+	Timestamp int32  `json:"timestamp"`
+	Type      string `json:"event"`
+	Output    string `json:"output"`
+	Directive string `json:"directive"`
+	ExitCode  int32  `json:"exit_code"`
+	JobResult string `json:"job_result"`
+}
+
+func NewLogsV1AlphaFromJson(data []byte) (*LogsV1Alpha, error) {
+	t := LogsV1Alpha{}
+	err := json.Unmarshal(data, &t)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// #nosec
 const secretEditDangerMessage = `
 # WARNING! Secrets cannot be updated, only replaced. Once the change is applied, the old values will be lost forever.
 # Note: You can exit without saving to skip.

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	httpmock "github.com/jarcoal/httpmock"
+)
+
+const Events = `{
+  "events": [
+		{"event": "job_started", "timestamp": 1624541916},
+		{"event": "cmd_started", "timestamp": 1624541916, "directive": "Exporting environment variables"},
+		{"event": "cmd_output", "timestamp": 1624541916, "output": "Exporting VAR1"},
+		{"event": "cmd_output", "timestamp": 1624541916, "output": "Exporting VAR2"},
+		{"event": "cmd_finished", "timestamp": 1624541916, "directive": "Exporting environment variables", "exit_code": 0},
+		{"event": "job_finished", "timestamp": 1624541916, "result": "passed"}
+	]
+}
+`
+
+func TestLogs__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/logs/job-123",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			return httpmock.NewStringResponse(200, Events), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"logs", "job-123", "-v"})
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET /logs/job-123")
+	}
+}


### PR DESCRIPTION
https://github.com/renderedtext/project-tasks/issues/1285

Refactor the logs command to use the newly added [/api/v1alpha/logs/{job_id} endpoint](https://github.com/renderedtext/alles/pull/1403).