### PR TITLE
feat: expose creation timestamp filters for pipelines/workflows

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -549,7 +549,7 @@ func init() {
 	GetPplCmd.Flags().StringP("project-id", "i", "",
 		"project id; if not specified will be inferred from git origin")
 	GetPplCmd.Flags().DurationP("age", "", DefaultListingAge,
-		"filter for listing pipelines based on age; by default, we list only pipelines created in the last 90 days")
+		"list only pipelines created in the given duration; it accepts a Go duration. e.g. 24h, 30m, 60s")
 	getCmd.AddCommand(GetPplCmd)
 
 	getCmd.AddCommand(GetWfCmd)
@@ -558,7 +558,7 @@ func init() {
 	GetWfCmd.Flags().StringP("project-id", "i", "",
 		"project id; if not specified will be inferred from git origin")
 	GetWfCmd.Flags().DurationP("age", "", DefaultListingAge,
-		"filter for listing pipelines based on age; by default, we list only pipelines created in the last 90 days")
+		"list only workflows created in the given duration; it accepts a Go duration. e.g. 24h, 30m, 60s")
 
 	getCmd.AddCommand(GetDTCmd)
 	GetDTCmd.Flags().StringP("project-name", "p", "",

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -428,10 +428,10 @@ func Test__GetPipelines__WithCreationTimestampFilters(t *testing.T) {
 		},
 	)
 
-	threeMonthsAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*90).Unix())
-	oneMonthAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*30).Unix())
-
-	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/pipelines?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", threeMonthsAgo, oneMonthAgo)
+	age := 720 * time.Hour
+	createdBefore := fmt.Sprintf("%d", time.Now().Unix())
+	createdAfter := fmt.Sprintf("%d", time.Now().Add(-1*age).Unix())
+	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/pipelines?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", createdAfter, createdBefore)
 	httpmock.RegisterResponder("GET", url,
 		func(req *http.Request) (*http.Response, error) {
 			received = true
@@ -456,10 +456,8 @@ func Test__GetPipelines__WithCreationTimestampFilters(t *testing.T) {
 		"pipelines",
 		"--project-name",
 		"foo",
-		"--created-after",
-		threeMonthsAgo,
-		"--created-before",
-		oneMonthAgo,
+		"--age",
+		age.String(),
 	})
 
 	RootCmd.Execute()
@@ -693,10 +691,10 @@ func Test__GetWorkflows__WithCreationTimestampFilters(t *testing.T) {
 		},
 	)
 
-	threeMonthsAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*90).Unix())
-	oneMonthAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*30).Unix())
-
-	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/plumber-workflows?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", threeMonthsAgo, oneMonthAgo)
+	age := 720 * time.Hour
+	createdBefore := fmt.Sprintf("%d", time.Now().Unix())
+	createdAfter := fmt.Sprintf("%d", time.Now().Add(-1*age).Unix())
+	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/plumber-workflows?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", createdAfter, createdBefore)
 	httpmock.RegisterResponder("GET", url,
 		func(req *http.Request) (*http.Response, error) {
 			received = true
@@ -721,10 +719,8 @@ func Test__GetWorkflows__WithCreationTimestampFilters(t *testing.T) {
 		"workflows",
 		"--project-name",
 		"foo",
-		"--created-after",
-		threeMonthsAgo,
-		"--created-before",
-		oneMonthAgo,
+		"--age",
+		age.String(),
 	})
 
 	RootCmd.Execute()

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	httpmock "github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -360,6 +361,114 @@ func Test__GetAgent__Response200(t *testing.T) {
 	}
 }
 
+func Test__GetPipelines__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects/foo",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `{
+				"metadata": {
+					"id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe"
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	httpmock.RegisterResponder("GET", `=~^https:\/\/org\.semaphoretext\.xyz\/api\/v1alpha\/pipelines\?created_after=\d+&created_before=\d+&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe`,
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `[{
+				"pipeline": {
+					"ppl_id": "494b76aa-f3f0-4ecf-b5ef-c389591a01be",
+					"name": "snapshot test",
+				"state": "done",
+				"result": "passed",
+					"result_reason": "test",
+				"error_description": ""
+				}
+			}]`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "pipelines", "--project-name", "foo"})
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET /pipelines")
+	}
+}
+
+func Test__GetPipelines__WithCreationTimestampFilters(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects/foo",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `{
+				"metadata": {
+					"id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe"
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	threeMonthsAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*90).Unix())
+	oneMonthAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*30).Unix())
+
+	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/pipelines?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", threeMonthsAgo, oneMonthAgo)
+	httpmock.RegisterResponder("GET", url,
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `[{
+				"pipeline": {
+					"ppl_id": "494b76aa-f3f0-4ecf-b5ef-c389591a01be",
+					"name": "snapshot test",
+				"state": "done",
+				"result": "passed",
+					"result_reason": "test",
+				"error_description": ""
+				}
+			}]`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{
+		"get",
+		"pipelines",
+		"--project-name",
+		"foo",
+		"--created-after",
+		threeMonthsAgo,
+		"--created-before",
+		oneMonthAgo,
+	})
+
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET /pipelines")
+	}
+}
+
 func Test__GetPipeline__Response200(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -537,7 +646,7 @@ func Test__GetWorkflows__Response200(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/plumber-workflows?project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+	httpmock.RegisterResponder("GET", `=~^https:\/\/org\.semaphoretext\.xyz\/api\/v1alpha\/plumber-workflows\?created_after=\d+&created_before=\d+&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe`,
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 
@@ -560,6 +669,67 @@ func Test__GetWorkflows__Response200(t *testing.T) {
 	RootCmd.Execute()
 
 	if received == false {
-		t.Error("Expected the API to receive GET secrets/aaaaaaa")
+		t.Error("Expected the API to receive GET /plumber-workflows")
+	}
+}
+
+func Test__GetWorkflows__WithCreationTimestampFilters(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects/foo",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `{
+				"metadata": {
+					"id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe"
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	threeMonthsAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*90).Unix())
+	oneMonthAgo := fmt.Sprintf("%d", time.Now().Add(-1*time.Hour*24*30).Unix())
+
+	url := fmt.Sprintf("https://org.semaphoretext.xyz/api/v1alpha/plumber-workflows?created_after=%s&created_before=%s&project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe", threeMonthsAgo, oneMonthAgo)
+	httpmock.RegisterResponder("GET", url,
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			p := `[{
+				"wf_id": "b129e277-4aa5-4308-8e31-ec825815e335",
+				"requester_id": "92f81b82-3584-4852-ab28-4866624bed1e",
+				"project_id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+				"initial_ppl_id": "92f81b82-3584-4852-ab28-4866624bed1e",
+				"created_at": {
+					"seconds": 1533833523,
+					"nanos": 537460000
+				}
+			}]`
+
+			return httpmock.NewStringResponse(200, p), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{
+		"get",
+		"workflows",
+		"--project-name",
+		"foo",
+		"--created-after",
+		threeMonthsAgo,
+		"--created-before",
+		oneMonthAgo,
+	})
+
+	RootCmd.Execute()
+
+	if received == false {
+		t.Error("Expected the API to receive GET /plumber-workflows")
 	}
 }

--- a/cmd/pipelines/get.go
+++ b/cmd/pipelines/get.go
@@ -37,10 +37,10 @@ func describe(c client.PipelinesApiV1AlphaApi, id string) ([]byte, bool) {
 	return pplY, pplJ.IsDone()
 }
 
-func List(projectID string) {
+func List(projectID string, options client.ListOptions) {
 	fmt.Printf("%s\n", projectID)
 	c := client.NewPipelinesV1AlphaApi()
-	body, err := c.ListPpl(projectID)
+	body, err := c.ListPplWithOptions(projectID, options)
 	utils.Check(err)
 
 	prettyPrintPipelineList(body)

--- a/cmd/workflows/get.go
+++ b/cmd/workflows/get.go
@@ -11,9 +11,9 @@ import (
 	"github.com/semaphoreci/cli/cmd/utils"
 )
 
-func List(projectID string) {
+func List(projectID string, options client.ListOptions) {
 	wfClient := client.NewWorkflowV1AlphaApi()
-	workflows, err := wfClient.ListWorkflows(projectID)
+	workflows, err := wfClient.ListWorkflowsWithOptions(projectID, options)
 	utils.Check(err)
 
 	prettyPrint(workflows)


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6961

### Issue

For old projects with lots and lots of pipelines/workflows, listing those resources can take quite some time.

### Solution

Make use of the `created_after` and `created_before` arguments in these APIs:
- By default, list resources created in the last 3 months.
- Allow the user to override those defaults by using the `--age` argument.