### PR TITLE
feat: page size and pagination for get notifications cmd

### DIFF
--- a/api/client/base_client.go
+++ b/api/client/base_client.go
@@ -113,12 +113,17 @@ func (c *BaseClient) List(kind string) ([]byte, int, error) {
 }
 
 func (c *BaseClient) ListWithParams(kind string, query url.Values) ([]byte, int, error) {
+	if len(query) == 0 {
+		return c.List(kind)
+	}
 	url := fmt.Sprintf("https://%s/api/%s/%s?%s", c.host, c.apiVersion, kind, query.Encode())
 
 	log.Printf("GET %s\n", url)
 
 	req, err := http.NewRequest("GET", url, nil)
-
+	if err != nil {
+		return nil, 0, err
+	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.authToken))
 	req.Header.Set("User-Agent", UserAgent)

--- a/api/client/notifications_v1_alpha.go
+++ b/api/client/notifications_v1_alpha.go
@@ -24,8 +24,18 @@ func NewNotificationsV1AlphaApi() NotificationsV1AlphaApi {
 	}
 }
 
-func (c *NotificationsV1AlphaApi) ListNotifications() (*models.NotificationListV1Alpha, error) {
-	body, status, err := c.BaseClient.List(c.ResourceNamePlural)
+func (c *NotificationsV1AlphaApi) ListNotifications(pageSize int32, pageToken string) (*models.NotificationListV1Alpha, error) {
+	query := ""
+	if pageSize > 0 {
+		query = fmt.Sprintf("?page_size=%d", pageSize)
+		if pageToken != "" {
+			query = fmt.Sprintf("%s&page_token=%s", query, pageToken)
+		}
+	} else if pageToken != "" {
+		query = fmt.Sprintf("?page_token=%s", pageToken)
+	}
+
+	body, status, err := c.BaseClient.List(c.ResourceNamePlural + query)
 
 	if err != nil {
 		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)

--- a/api/client/notifications_v1_alpha.go
+++ b/api/client/notifications_v1_alpha.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	models "github.com/semaphoreci/cli/api/models"
 )
@@ -25,17 +26,17 @@ func NewNotificationsV1AlphaApi() NotificationsV1AlphaApi {
 }
 
 func (c *NotificationsV1AlphaApi) ListNotifications(pageSize int32, pageToken string) (*models.NotificationListV1Alpha, error) {
-	query := ""
+	query := url.Values{}
+
 	if pageSize > 0 {
-		query = fmt.Sprintf("?page_size=%d", pageSize)
-		if pageToken != "" {
-			query = fmt.Sprintf("%s&page_token=%s", query, pageToken)
-		}
-	} else if pageToken != "" {
-		query = fmt.Sprintf("?page_token=%s", pageToken)
+		query.Add("page_size", fmt.Sprintf("%d", pageSize))
 	}
 
-	body, status, err := c.BaseClient.List(c.ResourceNamePlural + query)
+	if pageToken != "" {
+		query.Add("page_token", pageToken)
+	}
+
+	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 
 	if err != nil {
 		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)

--- a/api/models/notification_list_v1_alpha.go
+++ b/api/models/notification_list_v1_alpha.go
@@ -5,7 +5,8 @@ import (
 )
 
 type NotificationListV1Alpha struct {
-	Notifications []NotificationV1Alpha `json:"notifications" yaml:"notifications"`
+	Notifications   []NotificationV1Alpha `json:"notifications" yaml:"notifications"`
+	NextPageToken   string                `json:"next_page_token,omitempty" yaml:"next_page_token,omitempty"`
 }
 
 func NewNotificationListV1AlphaFromJson(data []byte) (*NotificationListV1Alpha, error) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -523,6 +523,8 @@ func init() {
 	RootCmd.AddCommand(getCmd)
 
 	getNotificationCmd := NewGetNotificationCmd()
+	getNotificationCmd.Flags().Int32P("page-size", "s", 0, "Number of items per page (max 300)")
+	getNotificationCmd.Flags().StringP("page-token", "t", "", "Token for the next page")
 
 	getCmd.AddCommand(GetDashboardCmd)
 	getCmd.AddCommand(getNotificationCmd)

--- a/cmd/get_notification.go
+++ b/cmd/get_notification.go
@@ -49,7 +49,10 @@ func RunGetNotification(cmd *cobra.Command, args []string) {
 func RunListNotifications(cmd *cobra.Command, args []string) {
 	c := client.NewNotificationsV1AlphaApi()
 
-	notifList, err := c.ListNotifications()
+	pageSize, _ := cmd.Flags().GetInt32("page-size")
+	pageToken, _ := cmd.Flags().GetString("page-token")
+
+	notifList, err := c.ListNotifications(pageSize, pageToken)
 
 	utils.Check(err)
 
@@ -64,6 +67,11 @@ func RunListNotifications(cmd *cobra.Command, args []string) {
 		utils.Check(err)
 
 		fmt.Fprintf(w, "%s\t%s\n", n.Metadata.Name, utils.RelativeAgeForHumans(updateTime))
+	}
+
+	if notifList.NextPageToken != "" {
+		fmt.Fprintf(w, "\nNext page token: %s\n", notifList.NextPageToken)
+		fmt.Fprintf(w, "To view next page, run: sem get notifications --page-token %s\n", notifList.NextPageToken)
 	}
 
 	if err := w.Flush(); err != nil {

--- a/cmd/get_notification.go
+++ b/cmd/get_notification.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	client "github.com/semaphoreci/cli/api/client"
+	models "github.com/semaphoreci/cli/api/models"
 
 	"github.com/semaphoreci/cli/cmd/utils"
 	"github.com/spf13/cobra"
@@ -51,27 +52,36 @@ func RunListNotifications(cmd *cobra.Command, args []string) {
 
 	pageSize, _ := cmd.Flags().GetInt32("page-size")
 	pageToken, _ := cmd.Flags().GetString("page-token")
+	fetchAll := (pageSize == 0) && (pageToken == "")
 
-	notifList, err := c.ListNotifications(pageSize, pageToken)
+	var allNotifications []models.NotificationV1Alpha
 
-	utils.Check(err)
+	for {
+		notifList, err := c.ListNotifications(pageSize, pageToken)
+		utils.Check(err)
+
+		allNotifications = append(allNotifications, notifList.Notifications...)
+		pageToken = notifList.NextPageToken
+
+		if !fetchAll || notifList.NextPageToken == "" {
+			break
+		}
+	}
 
 	const padding = 3
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
 
 	fmt.Fprintln(w, "NAME\tAGE")
 
-	for _, n := range notifList.Notifications {
+	for _, n := range allNotifications {
 		updateTime, err := n.Metadata.UpdateTime.Int64()
-
 		utils.Check(err)
 
 		fmt.Fprintf(w, "%s\t%s\n", n.Metadata.Name, utils.RelativeAgeForHumans(updateTime))
 	}
-
-	if notifList.NextPageToken != "" {
-		fmt.Fprintf(w, "\nNext page token: %s\n", notifList.NextPageToken)
-		fmt.Fprintf(w, "To view next page, run: sem get notifications --page-token %s\n", notifList.NextPageToken)
+	if !fetchAll && pageToken != "" {
+		fmt.Fprintf(w, "\nNext page token: %s\n", pageToken)
+		fmt.Fprintf(w, "To view next page, run: sem get notifications --page-token %s\n", pageToken)
 	}
 
 	if err := w.Flush(); err != nil {

--- a/cmd/get_notification_test.go
+++ b/cmd/get_notification_test.go
@@ -45,35 +45,6 @@ func Test__ListNotifications__Response200(t *testing.T) {
 	assert.True(t, received, "Expected the API to receive GET notifications")
 }
 
-func Test__ListNotifications__WithPageToken(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	received := false
-
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications?page_size=50&page_token=abc123",
-		func(req *http.Request) (*http.Response, error) {
-			received = true
-
-			response := `{
-				"notifications": [{
-					"metadata": {
-						"name": "notif2",
-						"update_time": "125"
-					}
-				}]
-			}`
-
-			return httpmock.NewStringResponse(200, response), nil
-		},
-	)
-
-	RootCmd.SetArgs([]string{"get", "notifications", "--page-token", "abc123", "--page-size", "50"})
-	RootCmd.Execute()
-
-	assert.True(t, received, "Expected the API to receive GET notifications with page token")
-}
-
 func Test__GetNotification__Response200(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -99,4 +70,64 @@ func Test__GetNotification__Response200(t *testing.T) {
 	RootCmd.Execute()
 
 	assert.True(t, received, "Expected the API to receive GET notifications/test-notif")
+}
+
+func Test__ListNotifications__WithAllFlag(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	page1Called := false
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications",
+		func(req *http.Request) (*http.Response, error) {
+			page1Called = true
+
+			n1 := `{
+				"metadata": {
+					"name": "notif1",
+					"update_time": "124"
+				}
+			}`
+
+			n2 := `{
+				"metadata": {
+					"name": "notif2",
+					"update_time": "125"
+				}
+			}`
+
+			response := fmt.Sprintf(`{
+				"notifications": [%s,%s],
+				"next_page_token": "page2"
+			}`, n1, n2)
+
+			return httpmock.NewStringResponse(200, response), nil
+		},
+	)
+
+	page2Called := false
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications?page_token=page2",
+		func(req *http.Request) (*http.Response, error) {
+			page2Called = true
+
+			n3 := `{
+				"metadata": {
+					"name": "notif3",
+					"update_time": "126"
+				}
+			}`
+
+			response := fmt.Sprintf(`{
+				"notifications": [%s],
+				"next_page_token": ""
+			}`, n3)
+
+			return httpmock.NewStringResponse(200, response), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "notifications"})
+	RootCmd.Execute()
+
+	assert.True(t, page1Called, "Expected the API to receive GET notifications for first page")
+	assert.True(t, page2Called, "Expected the API to receive GET notifications for second page")
 }

--- a/cmd/get_notification_test.go
+++ b/cmd/get_notification_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	httpmock "github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__ListNotifications__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			n1 := `{
+				"metadata": {
+					"name": "notif1",
+					"update_time": "124"
+				}
+			}`
+
+			n2 := `{
+				"metadata": {
+					"name": "notif2",
+					"update_time": "125"
+				}
+			}`
+
+			notifications := fmt.Sprintf(`{"notifications":[%s,%s]}`, n1, n2)
+
+			return httpmock.NewStringResponse(200, notifications), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "notifications"})
+	RootCmd.Execute()
+
+	assert.True(t, received, "Expected the API to receive GET notifications")
+}
+
+func Test__ListNotifications__WithPageToken(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications?page_size=50&page_token=abc123",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			response := `{
+				"notifications": [{
+					"metadata": {
+						"name": "notif2",
+						"update_time": "125"
+					}
+				}]
+			}`
+
+			return httpmock.NewStringResponse(200, response), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "notifications", "--page-token", "abc123", "--page-size", "50"})
+	RootCmd.Execute()
+
+	assert.True(t, received, "Expected the API to receive GET notifications with page token")
+}
+
+func Test__GetNotification__Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	received := false
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/notifications/test-notif",
+		func(req *http.Request) (*http.Response, error) {
+			received = true
+
+			notification := `{
+				"metadata": {
+					"name": "test-notif",
+					"update_time": "124"
+				}
+			}`
+
+			return httpmock.NewStringResponse(200, notification), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"get", "notifications", "test-notif"})
+	RootCmd.Execute()
+
+	assert.True(t, received, "Expected the API to receive GET notifications/test-notif")
+}


### PR DESCRIPTION
### Add Pagination Support for `sem get notifications`  

**Issue:**  
[`sem get notifications`](https://github.com/renderedtext/tasks/issues/7499) does not currently support pagination or page size configuration, limiting results to a maximum of 100 entries.  

**Solution:**  
- The default behavior of `sem get notifications` is to iterate through all result pages and retrieve all notifications.
- Introduced `--page-size` (`-s`) to specify the number of results per page (up to 300).  
- Added `--page-token` (`-t`) to allow navigation through pages.  
- The response now includes a "Next page token" for fetching subsequent results.  

**Example Usage:**  
```sh
sem get notifications
```
**Output:**
```sh
NAME        AGE
test-1      2d
test-10     2d
test-100    2d
test-1000   2d
test-101    2d
test-102    2d
test-103    2d
...
test-993    2d
test-994    2d
test-995    2d
test-996    2d
test-997    2d
test-998    2d
test-999    2d
```

If you use the page parameter or limit the page size and there are more results, you will receive a message about the next page token:

```sh
sem get notifications --page-size 10
```
**Output:**  
```sh
NAME        AGE 
test-0      6m
test-1      5m
test-10     5m
test-100    4m
test-1000   36s
test-101    4m
test-102    4m
test-103    4m
test-104    4m
test-105    4m

Next page token: g3QAAAACZAACaWRtAAAAJDVmMTU2ZGI5LWJhM2MtNDkwOS04M2VjLTdmMzQ4YTE4NTk0N2QABG5hbWVtAAAACHRlc3QtMTA1
To view next page, run: sem get notifications --page-token g3QAAAACZAACaWRtAAAAJDVmMTU2ZGI5LWJhM2MtNDkwOS04M2VjLTdmMzQ4YTE4NTk0N2QABG5hbWVtAAAACHRlc3QtMTA1
```

```sh
sem get notifications --page-token g3QAAAACZAACaWRtAAAAJDVmMTU2ZGI5LWJhM2MtNDkwOS04M2VjLTdmMzQ4YTE4NTk0N2QABG5hbWVtAAAACHRlc3QtMTA1 --page-size 10
```
```sh
NAME       AGE 
test-106   4m
test-107   4m
test-108   4m
test-109   4m
test-11    5m
test-110   4m
test-111   4m
test-112   4m
test-113   4m
test-114   4m

Next page token: g3QAAAACZAACaWRtAAAAJDA2NThmMjhhLWZiNmEtNDk0MS1hZmFlLWI5OTlhMzQ3OWQ2OWQABG5hbWVtAAAACHRlc3QtMTE0
To view next page, run: sem get notifications --page-token g3QAAAACZAACaWRtAAAAJDA2NThmMjhhLWZiNmEtNDk0MS1hZmFlLWI5OTlhMzQ3OWQ2OWQABG5hbWVtAAAACHRlc3QtMTE0
```
