### PR TITLE
feat: list all projects using pagination in v1alpha/projects

### DIFF
--- a/api/client/agent_v1_alpha.go
+++ b/api/client/agent_v1_alpha.go
@@ -36,7 +36,7 @@ func (c *AgentApiV1AlphaApi) ListAgents(agentType string, cursor string) (*model
 		query.Add("cursor", cursor)
 	}
 
-	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 
 	if err != nil {
 		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)

--- a/api/client/base_client.go
+++ b/api/client/base_client.go
@@ -112,17 +112,14 @@ func (c *BaseClient) List(kind string) ([]byte, int, error) {
 	return body, resp.StatusCode, err
 }
 
-func (c *BaseClient) ListWithParams(kind string, query url.Values) ([]byte, int, error) {
-	if len(query) == 0 {
-		return c.List(kind)
-	}
+func (c *BaseClient) ListWithParams(kind string, query url.Values) ([]byte, int, http.Header, error) {
 	url := fmt.Sprintf("https://%s/api/%s/%s?%s", c.host, c.apiVersion, kind, query.Encode())
 
 	log.Printf("GET %s\n", url)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.authToken))
@@ -132,7 +129,7 @@ func (c *BaseClient) ListWithParams(kind string, query url.Values) ([]byte, int,
 	resp, err := client.Do(req)
 
 	if err != nil {
-		return []byte(""), 0, err
+		return []byte(""), 0, nil, err
 	}
 
 	defer resp.Body.Close()
@@ -144,7 +141,7 @@ func (c *BaseClient) ListWithParams(kind string, query url.Values) ([]byte, int,
 
 	log.Println(string(body))
 
-	return body, resp.StatusCode, err
+	return body, resp.StatusCode, resp.Header, err
 }
 
 func (c *BaseClient) Delete(kind string, name string) ([]byte, int, error) {

--- a/api/client/jobs_v1_alpha.go
+++ b/api/client/jobs_v1_alpha.go
@@ -32,7 +32,7 @@ func (c *JobsApiV1AlphaApi) ListJobs(states []string) (*models.JobListV1Alpha, e
 		query.Add("states", s)
 	}
 
-	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))

--- a/api/client/notifications_v1_alpha.go
+++ b/api/client/notifications_v1_alpha.go
@@ -36,7 +36,7 @@ func (c *NotificationsV1AlphaApi) ListNotifications(pageSize int32, pageToken st
 		query.Add("page_token", pageToken)
 	}
 
-	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 
 	if err != nil {
 		return nil, fmt.Errorf("connecting to Semaphore failed '%s'", err)

--- a/api/client/pipelines_v1_alpha.go
+++ b/api/client/pipelines_v1_alpha.go
@@ -125,7 +125,7 @@ func (c *PipelinesApiV1AlphaApi) ListPplWithOptions(projectID string, options Li
 		query.Add("created_before", fmt.Sprintf("%d", options.CreatedBefore))
 	}
 
-	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))

--- a/api/client/workflows_v1_alpha.go
+++ b/api/client/workflows_v1_alpha.go
@@ -53,7 +53,7 @@ func (c *WorkflowApiV1AlphaApi) ListWorkflowsWithOptions(projectID string, optio
 		query.Add("created_before", fmt.Sprintf("%d", options.CreatedBefore))
 	}
 
-	body, status, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -294,7 +294,7 @@ var GetProjectCmd = &cobra.Command{
 		c := client.NewProjectV1AlphaApi()
 
 		if len(args) == 0 {
-			projectList, err := c.ListProjects()
+			projectList, err := c.ListProjectsPaginated(1, 500)
 
 			utils.Check(err)
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -17,7 +17,7 @@ func Test__ListProjects__Response200(t *testing.T) {
 
 	received := false
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects",
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/projects?page=1&page_size=500",
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 


### PR DESCRIPTION
#### Description

`sem get projects` command uses the `v1alpha/projects` endpoint, which currently [does not support pagination](https://github.com/renderedtext/tasks/issues/7953).

With the updates introduced in the [Semaphore PR](https://github.com/semaphoreio/semaphore/tree/dk/projecthub-rest-api/add_pagination), pagination support has been added.
This change updates the command to use pagination, ensuring it iterates through all projects (instead of returning only the first 500), and returns the complete result.
