### PR TITLE
feat: add ability to detect current project

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,6 @@
 FROM golang:1.21
 
 RUN go install gotest.tools/gotestsum@v1.12.2
+RUN git config --global --add safe.directory /app
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 
 RUN go install gotest.tools/gotestsum@v1.12.2
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 	docker-compose run --rm cli gotestsum --format short-verbose --junitfile results.xml --packages="./..." -- -p 1
 
 build:
-	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -buildvcs=false -ldflags "-s -w -X main.version=$(shell git describe --tags --abbrev=0)" -o sem
+	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w -X main.version=$(shell git describe --tags --abbrev=0)" -o sem
 	tar -czvf /tmp/sem.tar.gz sem
 
 # Automation of CLI tagging.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 	docker-compose run --rm cli gotestsum --format short-verbose --junitfile results.xml --packages="./..." -- -p 1
 
 build:
-	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w -X main.version=$(shell git describe --tags --abbrev=0)" -o sem
+	docker-compose run --rm cli env GOOS=$(OS) GOARCH=$(ARCH) go build -buildvcs=false -ldflags "-s -w -X main.version=$(shell git describe --tags --abbrev=0)" -o sem
 	tar -czvf /tmp/sem.tar.gz sem
 
 # Automation of CLI tagging.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -290,20 +290,10 @@ var GetCurrentProjectCmd = &cobra.Command{
 	Long:    ``,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		c := client.NewProjectV1AlphaApi()
-
-		projectList, err := c.ListProjects()
-
+		project, err := utils.InferProject()
 		utils.Check(err)
 
-		projectName, err := utils.InferProjectName()
-		utils.Check(err)
-
-		for _, p := range projectList.Projects {
-			if p.Metadata.Name == projectName {
-				fmt.Println(p.Metadata.Id, p.Metadata.Name, p.Spec.Repository.Url)
-			}
-		}
+		fmt.Println(project.Metadata.Id, project.Metadata.Name, project.Spec.Repository.Url)
 
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -313,20 +313,13 @@ var GetProjectCmd = &cobra.Command{
 
 			utils.Check(err)
 
-			projectName, err := utils.InferProjectName()
-			utils.Check(err)
-
 			const padding = 3
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
 
 			fmt.Fprintln(w, "NAME\tREPOSITORY")
 
 			for _, p := range projectList.Projects {
-				if p.Metadata.Name == projectName {
-					fmt.Fprintf(w, "%s\t%s\t%s\n", p.Metadata.Name, p.Spec.Repository.Url, "(active)")
-				} else {
-					fmt.Fprintf(w, "%s\t%s\n", p.Metadata.Name, p.Spec.Repository.Url)
-				}
+				fmt.Fprintf(w, "%s\t%s\n", p.Metadata.Name, p.Spec.Repository.Url)
 			}
 
 			if err := w.Flush(); err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -288,7 +288,14 @@ var GetCurrentProjectCmd = &cobra.Command{
 	Use:     "current_project",
 	Short:   "Get project for current directory",
 	Aliases: []string{"cur"},
-	Long:    ``,
+Long: `Determine the Semaphore project associated with this repository.
+
+	Resolution order:
+	1. A remote selected by 'gh repo set-default', if present.
+	2. The 'origin' remote, when configured.
+	3. The 'upstream' remote, when configured.
+	4. Any remaining remote whose URL is shared by all candidates.
+	5. An explicit error when multiple distinct URLs remain.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		project, err := utils.InferProject()

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -293,7 +294,15 @@ var GetCurrentProjectCmd = &cobra.Command{
 		project, err := utils.InferProject()
 		utils.Check(err)
 
-		fmt.Println(project.Metadata.Id, project.Metadata.Name, project.Spec.Repository.Url)
+		doJSON, err := cmd.Flags().GetBool("json")
+		utils.Check(err)
+		if doJSON {
+			jsonBody, err := json.MarshalIndent(project, "", "  ")
+			utils.Check(err)
+			fmt.Println(string(jsonBody))
+		} else {
+			fmt.Println(project.Metadata.Id, project.Metadata.Name, project.Spec.Repository.Url)
+		}
 
 	},
 }
@@ -544,8 +553,10 @@ func init() {
 	getCmd.AddCommand(GetDashboardCmd)
 	getCmd.AddCommand(getNotificationCmd)
 	getCmd.AddCommand(GetProjectCmd)
-	getCmd.AddCommand(GetCurrentProjectCmd)
 	getCmd.AddCommand(GetAgentTypeCmd)
+
+	getCmd.AddCommand(GetCurrentProjectCmd)
+	GetCurrentProjectCmd.Flags().Bool("json", false, "print project information as json")
 
 	GetAgentsCmd.Flags().StringP("agent-type", "t", "",
 		"agent type; if specified, returns only agents for this agent type")

--- a/cmd/utils/project.go
+++ b/cmd/utils/project.go
@@ -38,6 +38,7 @@ func InferProject() (models.ProjectV1Alpha, error) {
 	project, err := getProjectFromUrls(originURLs)
 	if err != nil {
 		log.Printf("no project found for any configured remotes (%s)", strings.Join(originURLs, ", "))
+		return models.ProjectV1Alpha{}, fmt.Errorf("no project found for any configured remotes: %w", err)
 	}
 
 	return project, nil

--- a/cmd/utils/project.go
+++ b/cmd/utils/project.go
@@ -12,6 +12,40 @@ import (
 	"github.com/semaphoreci/cli/api/models"
 )
 
+type GitRemote struct {
+	Name string
+	URL string
+	Project models.ProjectV1Alpha
+}
+
+type GitRemoteList []GitRemote
+
+func (grl GitRemoteList) Contains(remoteNameOrUrl string) bool {
+	for _, gitRemote := range grl {
+		if gitRemote.Name == remoteNameOrUrl || gitRemote.URL == remoteNameOrUrl {
+			return true
+		}
+	}
+	return false
+}
+
+func (grl GitRemoteList) Get(remoteNameOrUrl string) (*GitRemote, error) {
+	for _, gitRemote := range grl {
+		if gitRemote.Name == remoteNameOrUrl || gitRemote.URL == remoteNameOrUrl {
+			return &gitRemote, nil
+		}
+	}
+	return &GitRemote{}, fmt.Errorf("no remote matching %s found in remote list")
+}
+
+func (grl GitRemoteList) URLs() []string {
+	urls := []string{}
+	for _, gitRemote := range grl {
+		urls = append(urls, gitRemote.URL)
+	}
+	return urls
+}
+
 func GetProjectId(name string) string {
 	projectClient := client.NewProjectV1AlphaApi()
 	project, err := projectClient.GetProject(name)
@@ -30,18 +64,64 @@ func InferProjectName() (string, error) {
 }
 
 func InferProject() (models.ProjectV1Alpha, error) {
-	originURLs, err := getAllGitRemoteURLs()
+	// Note that getAllGitRemotesAndProjects will only return remotes
+	// where the URL of that remote is configured in a project we got
+	// from the API, so this list is a list of remotes valid projects
+	// configured. All we have to do now is pick one.
+	gitRemotes, err := getAllGitRemotesAndProjects()
 	if err != nil {
 		return models.ProjectV1Alpha{}, err
 	}
 
-	project, err := getProjectFromUrls(originURLs)
+	// If the user is using GitHub and has run `gh repo set-default`, then
+	// we can get that 'base' remote name and see if we have a project for
+	// it.
+	ghBaseRemoteName, err := getGitHubBaseRemoteName()
 	if err != nil {
-		log.Printf("no project found for any configured remotes (%s)", strings.Join(originURLs, ", "))
-		return models.ProjectV1Alpha{}, fmt.Errorf("no project found for any configured remotes: %w", err)
+		log.Printf("tried looking for a `gh` base repo configuration, but found none.")
+	} else {
+		gitRemote, err := gitRemotes.Get(ghBaseRemoteName)
+		if err == nil {
+			return gitRemote.Project, nil
+		}
 	}
 
-	return project, nil
+	// If we only got one remote with a configured project, return it;
+	// alternately, if we got multiple, return the alphabetically first
+	// one.
+	if len(gitRemotes) == 1 {
+		return gitRemotes[0].Project, nil
+	}
+
+	// If we got an "origin" remote or an "upstream" remote, return that (in
+	// that order of preference)
+	for _, remoteName := range []string{"origin", "upstream"} {
+		remote, err := gitRemotes.Get(remoteName)
+		if err == nil {
+			return remote.Project, nil
+		}
+	}
+
+	// At this point, we have multiple remotes configured, all of which have
+	// a project configured in Semaphore, none of which are named "origin" or
+	// "upstream", and none of which are set as the gh base repo. The *most likely*
+	// explanation here is that the user has the same repo URL configured multiple
+	// times, or they're doing something extremely unusual. I'm not sure we can
+	// make the correct decision here.
+	allUrls := []string{}
+	for _, url := range gitRemotes.URLs() {
+		if !slices.Contains(allUrls, url) {
+			allUrls = append(allUrls, url)
+		}
+	}
+
+	// Okay, there's only one URL so we can just pick the relevant project.
+	if len(allUrls) == 1 {
+		return gitRemotes[0].Project, nil
+	}
+
+	// At this point we'd just be guessing, so let's give up
+	return models.ProjectV1Alpha{}, fmt.Errorf("found %d remotes with %d different URLs but cannot determine the correct one", len(gitRemotes), len(allUrls))
 }
 
 func getProjectIdFromUrl(url string) (string, error) {
@@ -70,6 +150,33 @@ func getProjectFromUrls(urls []string) (models.ProjectV1Alpha, error) {
 	return models.ProjectV1Alpha{}, fmt.Errorf("no project found in this org with a url matching any of this repository's remotes")
 }
 
+// getGitHubBaseRemoteName checks to see if the `gh` cli tool has set a default
+// remote for this repository. If not, or if we're not using Github at all, we
+// can just ignore the error.
+func getGitHubBaseRemoteName() (string, error) {
+	args := []string{"config", "--local", "--get-regexp", "gh-resolved"}
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		cmd_string := fmt.Sprintf("'%s %s'", "git", strings.Join(args, " "))
+		user_msg := "You are probably not in a git directory?"
+		return "", fmt.Errorf("%s failed with message: '%s'\n%s", cmd_string, err, user_msg)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+
+	if len(lines) == 0 {
+		return "", fmt.Errorf("no GitHub base remote configured for this repository")
+	}
+	if len(lines) > 1 {
+		return "", fmt.Errorf("got multiple lines when looking for GitHub base remote")
+	}
+
+	fields := strings.Fields(lines[0])
+	remoteName := strings.Split(fields[0], ".")[1]
+	return remoteName, nil
+}
+
 func getGitRemotes() ([]string, error) {
 	args := []string{"remote"}
 	cmd := exec.Command("git", args...)
@@ -94,6 +201,40 @@ func getGitRemoteUrl(remote string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(out)), nil
+}
+
+func getAllGitRemotesAndProjects() (GitRemoteList, error) {
+	args := []string{"config", "--local", "--get-regexp", "remote\\..*\\.url"}
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		cmd_string := fmt.Sprintf("'%s %s'", "git", strings.Join(args, " "))
+		user_msg := "You are probably not in a git directory?"
+		return GitRemoteList{}, fmt.Errorf("%s failed with message: '%s'\n%s", cmd_string, err, user_msg)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+
+	projectClient := client.NewProjectV1AlphaApi()
+	projects, err := projectClient.ListProjects()
+
+	remotes := GitRemoteList{}
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		keyFields := strings.Split(line, ".")
+		remoteName := keyFields[1]
+		url := fields[1]
+
+		for _, proj := range projects.Projects {
+			if proj.Spec.Repository.Url == url {
+				remotes = append(remotes, GitRemote{Name: remoteName, URL: url, Project: proj})
+				break
+			}
+		}
+
+	}
+
+	return remotes, nil
 }
 
 func getAllGitRemoteURLs() ([]string, error) {

--- a/cmd/utils/project.go
+++ b/cmd/utils/project.go
@@ -67,7 +67,7 @@ func getProjectFromUrls(urls []string) (models.ProjectV1Alpha, error) {
 		}
 	}
 
-	return models.ProjectV1Alpha{}, fmt.Errorf("project with urls '%s' not found in this org", strings.Join(urls, ", "))
+	return models.ProjectV1Alpha{}, fmt.Errorf("no project found in this org with a url matching any of this repository's remotes")
 }
 
 func getGitRemotes() ([]string, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/semaphoreci/cli
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
The Semaphore CLI tool has the ability to detect the current project, but there are a few caveats:

1. It relies on the assumption that `origin` is the upstream remote; this is not a safe assumption because when creating a fork the `gh` cli tool will rename the upstream remote to `upstream` and set the new fork to be `origin`.
2. This functionality is never exposed to the user directly

This means that if a user needs the current project ID (e.g. to trigger a pipeline via the API), they must get the list of all remote URLs themselves, get the list of all projects themselves, find a match between the two, and then call `sem get project <project name>` to get the project's ID.

This PR does a few things (updated from the previous implementation):

First, we add a new function `getAllGitRemotesAndProjects()`, which does the following:
1. Gets all the configured git remotes and their URLs via `git config`
2. Gets all the configured projects in the current Semaphore context
3. Produces a list of (remoteName, remoteURL, semaphoreProject) where the project URL matches the remote URL; in other words, every configured remote for which a configured project exists.

Secondly, we also add a small helper function, `getGitHubBaseRemoteName()`, which checks the repository's git configuration via `git config` to see if the user has run `gh repo set-default` to choose a default remote.

Thirdly, we refactor `InferProject()` to call `getAllGitRemotesAndProjects()` and then choose one of the results with the following detection logic:

1. If we only have one result, use that
2. If the user has used `gh repo set-default` and that remote is in the list, use that
3. If the results include an `origin` repo, use that; if not but there's an `upstream` repo, use that
4. If the multiple non-default, non-origin, non-upstream remotes all have the same URL, return the project matching that URL
5. At this point, we have multiple remotes with non-standard remote names and different URLs, all of which have different projects configured for them; we can't guess a correct project so give up.

The original `InferProject()` simply chose the `origin` remote and used that, so this new logic will cover those cases as well, and thus shouldn't cause issues with the rest of the codebase.

Lastly, we add a new `sem get current_project` (alias `sem get cur`) which simply prints out the project's metadata:

```
sem get current_project
04ebc08e-437f-45e0-9abd-b5d1d66bb126 projectname git@github.com:thisorg/project.git
```

Originally I was planning on highlighting the current project when a user did `sem get project` without an argument, but that ended up feeling messier than just having a separate command for it which a user could parse.

**Edit**: Added a `--json` flag to `current_project` to format the output as JSON (which includes far more data).

**Edit 2**: Bumped golang version from 1.20 to 1.21 to get the `slices` package (should go to 1.25 IMHO but this is a minimal change), and added `-buildvcs=false` to work around git permissions warnings in docker container when running `make build`

**Edit 3**: Completely rewrote almost everything into a vastly simplified and yet more complicated implementation.