### PR TITLE
fix: refactor editor command execution to handle file paths with spaces

### DIFF
--- a/cmd/utils/editor.go
+++ b/cmd/utils/editor.go
@@ -51,8 +51,7 @@ func EditYamlInEditor(objectName string, content string) (string, error) {
 
 	editor := config.GetEditor()
 
-	// #nosec
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("%s %s", editor, tmpfile.Name()))
+	cmd := newEditorCommand(editor, tmpfile.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	err = cmd.Start()
@@ -74,4 +73,11 @@ func EditYamlInEditor(objectName string, content string) (string, error) {
 	}
 
 	return string(editedContent), nil
+}
+
+// newEditorCommand returns a shell command that runs the configured editor with
+// filePath as a single argument, even when filePath contains spaces.
+func newEditorCommand(editor, filePath string) *exec.Cmd {
+	// #nosec G204 -- editor value is user-controlled CLI configuration.
+	return exec.Command("sh", "-c", fmt.Sprintf(`%s "$1"`, editor), "sem-editor", filePath)
 }

--- a/cmd/utils/editor_test.go
+++ b/cmd/utils/editor_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test__newEditorCommand__PathWithSpacesIsSingleArgument(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logPath := filepath.Join(tmpDir, "editor-args.log")
+	scriptPath := filepath.Join(tmpDir, "capture-args.sh")
+	filePath := filepath.Join(tmpDir, "Notifications-my notification.yml")
+
+	script := `#!/bin/sh
+log_path="$1"
+shift
+printf '%s\n' "$#" > "$log_path"
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$log_path"
+done
+`
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to create capture script: %v", err)
+	}
+
+	editor := scriptPath + " " + logPath
+	cmd := newEditorCommand(editor, filePath)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("editor command failed: %v (output: %s)", err, string(output))
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read captured args: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines in capture output, got %d", len(lines))
+	}
+
+	if lines[0] != "1" {
+		t.Fatalf("expected editor script to receive exactly one file path argument, got %q", lines[0])
+	}
+
+	if lines[1] != filePath {
+		t.Fatalf("expected file path %q, got %q", filePath, lines[1])
+	}
+}


### PR DESCRIPTION
Fixes `sem edit` for resources with spaces in their names by invoking the editor with the temp file path as a positional argument, so the path is not split by the shell. Adds a regression test to verify paths containing spaces are passed to the editor as a single argument.

Related [task](https://github.com/renderedtext/tasks/issues/9559).