### PR TITLE
fix: paginate sem get tasks to return all tasks for a project

### DIFF
--- a/api/client/tasks_v1_alpha.go
+++ b/api/client/tasks_v1_alpha.go
@@ -3,9 +3,11 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	models "github.com/semaphoreci/cli/api/models"
+	retry "github.com/semaphoreci/cli/api/retry"
 )
 
 type TasksApiV1AlphaApi struct {
@@ -25,21 +27,75 @@ func NewTasksV1AlphaApi() TasksApiV1AlphaApi {
 	}
 }
 
+// maxTaskPages caps pagination depth to prevent runaway loops;
+// at 200 items/page this allows up to 100k tasks per project.
+var maxTaskPages = 500
+
+// ListTasks fetches all tasks for a project using pagination and aggregates them.
 func (c *TasksApiV1AlphaApi) ListTasks(projectID string) (models.TaskListV1Alpha, error) {
 	query := url.Values{}
 	query.Add("project_id", projectID)
+	query.Add("page_size", "200")
 
-	body, status, _, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+	allTasks := make(models.TaskListV1Alpha, 0)
+	currentPage := 1
+	const maxFailures = 5
 
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("connecting to Semaphore failed '%s'", err))
+	for {
+		query.Set("page", fmt.Sprintf("%d", currentPage))
+
+		var page models.TaskListV1Alpha
+		var headers http.Header
+
+		err := retry.RetryWithMaxFailures(maxFailures, func() error {
+			page = nil
+			headers = nil
+
+			body, status, hdrs, err := c.BaseClient.ListWithParams(c.ResourceNamePlural, query)
+			headers = hdrs
+			if err != nil {
+				return fmt.Errorf("connecting to Semaphore failed: %w", err)
+			}
+			if status != http.StatusOK {
+				msg := string(body)
+				if len(msg) > 200 {
+					msg = msg[:200] + "...(truncated)"
+				}
+				httpErr := fmt.Errorf("http status %d with message \"%s\" received from upstream", status, msg)
+				if status >= 300 && status < 500 && status != http.StatusTooManyRequests {
+					return retry.NonRetryable(httpErr)
+				}
+				return httpErr
+			}
+
+			pageList, err := models.NewTaskListV1AlphaFromJSON(body)
+			if err != nil {
+				return retry.NonRetryable(fmt.Errorf("failed to deserialize tasks list: %w", err))
+			}
+			page = pageList
+			return nil
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed fetching page %d (after accumulating %d tasks from %d pages): %w",
+				currentPage, len(allTasks), currentPage-1, err)
+		}
+
+		allTasks = append(allTasks, page...)
+
+		if headers == nil {
+			return nil, fmt.Errorf("internal error: response headers missing after fetching page %d", currentPage)
+		}
+		if !hasNextPage(headers) {
+			break
+		}
+		if currentPage >= maxTaskPages {
+			return nil, fmt.Errorf("pagination safety limit reached (%d pages); results may be incomplete -- please narrow your query", maxTaskPages)
+		}
+		currentPage++
 	}
 
-	if status != 200 {
-		return nil, errors.New(fmt.Sprintf("http status %d with message \"%s\" received from upstream", status, body))
-	}
-
-	return models.NewTaskListV1AlphaFromJSON(body)
+	return allTasks, nil
 }
 
 func (c *TasksApiV1AlphaApi) DescribeTask(id string) (*models.TaskDescribeV1Alpha, error) {

--- a/api/client/tasks_v1_alpha.go
+++ b/api/client/tasks_v1_alpha.go
@@ -27,10 +27,6 @@ func NewTasksV1AlphaApi() TasksApiV1AlphaApi {
 	}
 }
 
-// maxTaskPages caps pagination depth to prevent runaway loops;
-// at 200 items/page this allows up to 100k tasks per project.
-var maxTaskPages = 500
-
 // ListTasks fetches all tasks for a project using pagination and aggregates them.
 func (c *TasksApiV1AlphaApi) ListTasks(projectID string) (models.TaskListV1Alpha, error) {
 	query := url.Values{}
@@ -40,6 +36,9 @@ func (c *TasksApiV1AlphaApi) ListTasks(projectID string) (models.TaskListV1Alpha
 	allTasks := make(models.TaskListV1Alpha, 0)
 	currentPage := 1
 	const maxFailures = 5
+	// maxTaskPages caps pagination depth to prevent runaway loops;
+	// at 200 items/page this allows up to 100k tasks per project.
+	const maxTaskPages = 500
 
 	for {
 		query.Set("page", fmt.Sprintf("%d", currentPage))
@@ -81,11 +80,12 @@ func (c *TasksApiV1AlphaApi) ListTasks(projectID string) (models.TaskListV1Alpha
 				currentPage, len(allTasks), currentPage-1, err)
 		}
 
+		if headers == nil {
+			return nil, fmt.Errorf("internal error: response headers missing after fetching page %d (accumulated %d tasks)", currentPage, len(allTasks))
+		}
+
 		allTasks = append(allTasks, page...)
 
-		if headers == nil {
-			return nil, fmt.Errorf("internal error: response headers missing after fetching page %d", currentPage)
-		}
 		if !hasNextPage(headers) {
 			break
 		}

--- a/cmd/get_tasks_test.go
+++ b/cmd/get_tasks_test.go
@@ -226,7 +226,7 @@ func Test__ListTasks__MultiPage(t *testing.T) {
 	page2Received := false
 
 	httpmock.RegisterRegexpResponder("GET",
-		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*page=1.*`),
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks.*[?&]page=1(?:&|$)`),
 		func(req *http.Request) (*http.Response, error) {
 			page1Received = true
 			body := `[
@@ -239,7 +239,7 @@ func Test__ListTasks__MultiPage(t *testing.T) {
 	)
 
 	httpmock.RegisterRegexpResponder("GET",
-		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*page=2.*`),
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks.*[?&]page=2(?:&|$)`),
 		func(req *http.Request) (*http.Response, error) {
 			page2Received = true
 			body := `[

--- a/cmd/get_tasks_test.go
+++ b/cmd/get_tasks_test.go
@@ -258,4 +258,5 @@ func Test__ListTasks__MultiPage(t *testing.T) {
 	assert.Len(t, tasks, 2, "Expected tasks from both pages to be aggregated")
 	assert.Equal(t, "t1", tasks[0].Name, "Expected first task from page 1")
 	assert.Equal(t, "t2", tasks[1].Name, "Expected second task from page 2")
+	assert.Equal(t, 2, httpmock.GetTotalCallCount(), "Expected exactly two HTTP requests; pagination must stop when Link: rel=next is absent")
 }

--- a/cmd/get_tasks_test.go
+++ b/cmd/get_tasks_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"net/http"
+	"regexp"
 	"testing"
 
+	client "github.com/semaphoreci/cli/api/client"
 	httpmock "github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,7 +27,8 @@ func Test__ListTasks__Response200(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/tasks?project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe`),
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 
@@ -68,7 +71,8 @@ func Test__ListTasks__WithProjectID(t *testing.T) {
 
 	received := false
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/tasks?project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe`),
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 
@@ -88,7 +92,8 @@ func Test__ListTasks__SuspendedTask(t *testing.T) {
 
 	received := false
 
-	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/tasks?project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*project_id=758cb945-7495-4e40-a9a1-4b3991c6a8fe`),
 		func(req *http.Request) (*http.Response, error) {
 			received = true
 
@@ -211,4 +216,46 @@ func Test__GetTasks__TaskAlias(t *testing.T) {
 	RootCmd.Execute()
 
 	assert.True(t, received, "Expected the 'task' alias to work for describe")
+}
+
+func Test__ListTasks__MultiPage(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	page1Received := false
+	page2Received := false
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*page=1.*`),
+		func(req *http.Request) (*http.Response, error) {
+			page1Received = true
+			body := `[
+                {"id": "11111111-1111-1111-1111-111111111111", "name": "t1", "project_id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe", "branch": "main", "pipeline_file": ".semaphore/t1.yml", "recurring": false}
+            ]`
+			resp := httpmock.NewStringResponse(200, body)
+			resp.Header.Set("Link", `<https://org.semaphoretext.xyz/api/v1alpha/tasks?page=2>; rel="next"`)
+			return resp, nil
+		},
+	)
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*page=2.*`),
+		func(req *http.Request) (*http.Response, error) {
+			page2Received = true
+			body := `[
+                {"id": "22222222-2222-2222-2222-222222222222", "name": "t2", "project_id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe", "branch": "main", "pipeline_file": ".semaphore/t2.yml", "recurring": false}
+            ]`
+			return httpmock.NewStringResponse(200, body), nil
+		},
+	)
+
+	c := client.NewTasksV1AlphaApi()
+	tasks, err := c.ListTasks("758cb945-7495-4e40-a9a1-4b3991c6a8fe")
+
+	assert.NoError(t, err)
+	assert.True(t, page1Received, "Expected page 1 to be fetched")
+	assert.True(t, page2Received, "Expected page 2 to be fetched (pagination must follow Link: rel=next)")
+	assert.Len(t, tasks, 2, "Expected tasks from both pages to be aggregated")
+	assert.Equal(t, "t1", tasks[0].Name, "Expected first task from page 1")
+	assert.Equal(t, "t2", tasks[1].Name, "Expected second task from page 2")
 }


### PR DESCRIPTION
## Summary

Fixes a pagination bug in `sem get tasks -p <project>`: it was silently truncating results to the first 30 tasks (one page) regardless of how many tasks the project had. A project with more than 30 tasks only showed the first 30; the rest were invisible from the CLI even though the UI showed them all.

### Root cause

`ListTasks` in `api/client/tasks_v1_alpha.go` issued a single `GET /api/v1alpha/tasks?project_id=…` and returned whatever came back, discarding the pagination headers. The v1alpha API paginates via `Link: rel="next"` — the headers are returned in every response (e.g. `Total: N  Per-Page: 30  Link: …?page=2…; rel="next"`), just unused.

### Fix

Rewrite `ListTasks` to loop with `page_size=200`, follow `Link: rel="next"` until exhausted, and aggregate every page into a single `TaskListV1Alpha`.

This mirrors the pattern established for `sem get pipelines` in #247 (now merged):
- `retry.RetryWithMaxFailures` with exponential backoff for transient failures (5xx, 429, transport errors)
- `retry.NonRetryable` for 3xx/4xx (except 429) and deserialization failures — no wasted retries
- Truncated error bodies (200 chars max) to keep CLI output readable
- Mid-pagination error messages include the page number and accumulated task count for debuggability
- Safety cap of 500 pages (100k tasks) to prevent runaway loops, with a loud error if hit
- Nil-header guard, checked before appending the page so partial state is not mutated on error

The CLI surface is unchanged — no new flags, same command, just works.

### Why this is safe

- No changes to `DescribeTask` or `RunTask`; pagination applies only to the list endpoint.
- The `hasNextPage` helper and `retry.RetryWithMaxFailures` / `NonRetryable` are reused unchanged from #247 — they are already unit-tested in `api/client/pipelines_v1_alpha_test.go` (`TestHasNextPage`) and `api/retry/with_max_failures_test.go` (`TestRetryWithMaxFailures`, `..._NonRetryable`, `..._Backoff`, `..._MixedRetryableAndNon`, `..._ErrorWrapsAttemptCount`).
- The three existing `Test__ListTasks__*` httpmock responders that matched task URLs exactly are switched to regexp responders that match on the project-id query param. This was needed because requests now also carry `page` and `page_size` parameters; an exact-string responder would no longer match.
- A new `Test__ListTasks__MultiPage` covers the new behavior. It uses anchored regexp patterns (`[?&]page=N(?:&|$)`) so the page-1 responder cannot accidentally match `page=10`/`page=11`/etc. The test asserts both responders fire, the call returns no error, the result has length 2, and both task names from the two pages are present in order.
- `go build ./...` passes; all `Test__ListTasks__*`, `Test__DescribeTask__*`, and `Test__GetTasks__*` tests pass.

## Test plan

- [x] Unit tests pass for single-page (existing tests, after URL-matcher swap), multi-page aggregation, and the unchanged describe/run paths
- [x] `go build ./...` succeeds
- [x] Manual smoke: run `sem get tasks -p <project>` against a project with 100+ tasks confirmed all are returned (locally-built binary returned the full task count matching the API `total` header; the released CLI returned 30)
- [x] Manual smoke: confirmed `sem get tasks <task-id>` (describe) is byte-identical to the released CLI, and `sem run task <task-id>` still triggers a workflow successfully

