### PR TITLE
feat: regex pattern validation of task parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- feat: surface `regex_pattern` and `validate_input_format` on task parameters so `sem get`, `sem edit`, `sem apply`, and `sem create` round-trip the new v1alpha API fields
+
 ### v0.28.1
 
 - feat: add troubleshoot command

--- a/api/models/project_v1_alpha.go
+++ b/api/models/project_v1_alpha.go
@@ -176,11 +176,13 @@ func (t *Task) MarshalYAML() (interface{}, error) {
 }
 
 type TaskParameter struct {
-	Name         string   `json:"name"`
-	Required     bool     `json:"required"`
-	Description  string   `json:"description,omitempty" yaml:"description,omitempty"`
-	DefaultValue string   `json:"default_value,omitempty" yaml:"default_value,omitempty"`
-	Options      []string `json:"options,omitempty" yaml:"options,omitempty"`
+	Name                string   `json:"name"`
+	Required            bool     `json:"required"`
+	Description         string   `json:"description,omitempty" yaml:"description,omitempty"`
+	DefaultValue        string   `json:"default_value,omitempty" yaml:"default_value,omitempty"`
+	Options             []string `json:"options,omitempty" yaml:"options,omitempty"`
+	ValidateInputFormat bool     `json:"validate_input_format,omitempty" yaml:"validate_input_format,omitempty"`
+	RegexPattern        string   `json:"regex_pattern,omitempty" yaml:"regex_pattern,omitempty"`
 }
 
 type ForkedPullRequests struct {

--- a/api/models/tasks_v1_alpha.go
+++ b/api/models/tasks_v1_alpha.go
@@ -10,11 +10,13 @@ const (
 )
 
 type TaskParameterV1Alpha struct {
-	Name         string   `json:"name" yaml:"name"`
-	Required     bool     `json:"required" yaml:"required"`
-	Description  string   `json:"description,omitempty" yaml:"description,omitempty"`
-	DefaultValue string   `json:"default_value,omitempty" yaml:"default_value,omitempty"`
-	Options      []string `json:"options,omitempty" yaml:"options,omitempty"`
+	Name                string   `json:"name" yaml:"name"`
+	Required            bool     `json:"required" yaml:"required"`
+	Description         string   `json:"description,omitempty" yaml:"description,omitempty"`
+	DefaultValue        string   `json:"default_value,omitempty" yaml:"default_value,omitempty"`
+	Options             []string `json:"options,omitempty" yaml:"options,omitempty"`
+	ValidateInputFormat bool     `json:"validate_input_format,omitempty" yaml:"validate_input_format,omitempty"`
+	RegexPattern        string   `json:"regex_pattern,omitempty" yaml:"regex_pattern,omitempty"`
 }
 
 type TaskV1Alpha struct {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -174,6 +174,78 @@ spec:
 	}
 }
 
+func Test__ApplyProject__FromYaml_TaskParameterRegexValidation_Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	yaml_file := `
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: Test
+  id: a13949b7-b2f6-4286-8f26-3962d7e97828
+spec:
+  visibility: public
+  repository:
+    url: "git@github.com:/semaphoreci/cli.git"
+    integration_type: github_token
+    pipeline_file: ".semaphore/semaphore.yml"
+    run_on:
+      - branches
+  tasks:
+    - name: release
+      description: "release task"
+      scheduled: false
+      branch: main
+      pipeline_file: ".semaphore/release.yml"
+      parameters:
+        - name: VERSION
+          required: true
+          default_value: "1.0.0"
+          validate_input_format: true
+          regex_pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        - name: ENV
+          required: false
+          default_value: staging
+`
+
+	yaml_file_path := "/tmp/project_task_params.yaml"
+	ioutil.WriteFile(yaml_file_path, []byte(yaml_file), 0644)
+
+	var received *models.ProjectV1Alpha
+
+	httpmock.RegisterResponder("PATCH", "https://org.semaphoretext.xyz/api/v1alpha/projects/a13949b7-b2f6-4286-8f26-3962d7e97828",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+			received, _ = models.NewProjectV1AlphaFromJson(body)
+
+			return httpmock.NewStringResponse(200, string(body)), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"apply", "-f", yaml_file_path})
+	RootCmd.Execute()
+
+	assert.NotNil(t, received)
+	assert.Len(t, received.Spec.Tasks, 1)
+
+	task := received.Spec.Tasks[0]
+	assert.Equal(t, "release", task.Name)
+	assert.Len(t, task.Parameters, 2)
+
+	versionParam := task.Parameters[0]
+	assert.Equal(t, "VERSION", versionParam.Name)
+	assert.Equal(t, true, versionParam.Required)
+	assert.Equal(t, "1.0.0", versionParam.DefaultValue)
+	assert.Equal(t, true, versionParam.ValidateInputFormat)
+	assert.Equal(t, `^[0-9]+\.[0-9]+\.[0-9]+$`, versionParam.RegexPattern)
+
+	envParam := task.Parameters[1]
+	assert.Equal(t, "ENV", envParam.Name)
+	assert.Equal(t, false, envParam.ValidateInputFormat, "absent regex toggle should default to false")
+	assert.Equal(t, "", envParam.RegexPattern, "absent regex pattern should default to empty")
+}
+
 func Test__ApplyDeploymentTarget__FromYaml_Response200(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -54,6 +54,69 @@ spec:
 	}
 }
 
+func Test__CreateProject__FromYaml_TaskParameterRegexValidation_Response200(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	yaml_file := `
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: Test
+spec:
+  visibility: public
+  repository:
+    url: "git@github.com:/semaphoreci/cli.git"
+    integration_type: github_token
+    pipeline_file: ".semaphore/semaphore.yml"
+    run_on:
+      - branches
+  tasks:
+    - name: release
+      description: "release task"
+      scheduled: false
+      branch: main
+      pipeline_file: ".semaphore/release.yml"
+      parameters:
+        - name: VERSION
+          required: true
+          default_value: "1.0.0"
+          validate_input_format: true
+          regex_pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+`
+
+	yaml_file_path := "/tmp/project_task_params_create.yaml"
+	ioutil.WriteFile(yaml_file_path, []byte(yaml_file), 0644)
+
+	var received *models.ProjectV1Alpha
+
+	httpmock.RegisterResponder("POST", "https://org.semaphoretext.xyz/api/v1alpha/projects",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := ioutil.ReadAll(req.Body)
+			received, _ = models.NewProjectV1AlphaFromJson(body)
+
+			return httpmock.NewStringResponse(200, string(body)), nil
+		},
+	)
+
+	RootCmd.SetArgs([]string{"create", "-f", yaml_file_path})
+	RootCmd.Execute()
+
+	assert.NotNil(t, received)
+	assert.Len(t, received.Spec.Tasks, 1)
+
+	task := received.Spec.Tasks[0]
+	assert.Equal(t, "release", task.Name)
+	assert.Len(t, task.Parameters, 1)
+
+	param := task.Parameters[0]
+	assert.Equal(t, "VERSION", param.Name)
+	assert.Equal(t, true, param.Required)
+	assert.Equal(t, "1.0.0", param.DefaultValue)
+	assert.Equal(t, true, param.ValidateInputFormat)
+	assert.Equal(t, `^[0-9]+\.[0-9]+\.[0-9]+$`, param.RegexPattern)
+}
+
 func Test__CreateNotification__FromYaml__Response200(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -316,7 +316,9 @@ func Test__EditProject__WithTasks__Response200(t *testing.T) {
 							"required":true,
 							"description":"param1 description",
 							"default_value":"option1",
-							"options":["option1", "option2"]
+							"options":["option1", "option2"],
+							"validate_input_format":true,
+							"regex_pattern":"^option[12]$"
 						}
 					]
 				}
@@ -371,6 +373,8 @@ func Test__EditProject__WithTasks__Response200(t *testing.T) {
 	assert.Equal(t, task_parameter.Description, "param1 description")
 	assert.Equal(t, task_parameter.DefaultValue, "option1")
 	assert.Equal(t, task_parameter.Options, []string{"option1", "option2"})
+	assert.Equal(t, task_parameter.ValidateInputFormat, true)
+	assert.Equal(t, task_parameter.RegexPattern, "^option[12]$")
 
 	// Test backward compatibility: Branch should auto-create Reference
 	assert.NotNil(t, task.Reference, "Reference should be auto-created from Branch")

--- a/cmd/get_tasks_test.go
+++ b/cmd/get_tasks_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	client "github.com/semaphoreci/cli/api/client"
 	httpmock "github.com/jarcoal/httpmock"
+	client "github.com/semaphoreci/cli/api/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -259,4 +259,101 @@ func Test__ListTasks__MultiPage(t *testing.T) {
 	assert.Equal(t, "t1", tasks[0].Name, "Expected first task from page 1")
 	assert.Equal(t, "t2", tasks[1].Name, "Expected second task from page 2")
 	assert.Equal(t, 2, httpmock.GetTotalCallCount(), "Expected exactly two HTTP requests; pagination must stop when Link: rel=next is absent")
+}
+
+func Test__DescribeTask__WithParameterRegexValidation(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	taskID := "bb2ba294-d4b3-48bc-90a7-12dd56e9424c"
+
+	httpmock.RegisterResponder("GET", "https://org.semaphoretext.xyz/api/v1alpha/tasks/"+taskID,
+		func(req *http.Request) (*http.Response, error) {
+			body := `{
+				"schedule": {
+					"id": "bb2ba294-d4b3-48bc-90a7-12dd56e9424c",
+					"name": "release",
+					"project_id": "aa1ba294-d4b3-48bc-90a7-12dd56e9424a",
+					"branch": "main",
+					"pipeline_file": ".semaphore/release.yml",
+					"parameters": [
+						{
+							"name": "VERSION",
+							"required": true,
+							"default_value": "1.0.0",
+							"validate_input_format": true,
+							"regex_pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+						},
+						{
+							"name": "ENV",
+							"required": false,
+							"default_value": "staging"
+						}
+					]
+				}
+			}`
+			return httpmock.NewStringResponse(200, body), nil
+		},
+	)
+
+	c := client.NewTasksV1AlphaApi()
+	task, err := c.DescribeTask(taskID)
+
+	assert.NoError(t, err)
+	assert.Len(t, task.Schedule.Parameters, 2)
+
+	versionParam := task.Schedule.Parameters[0]
+	assert.Equal(t, "VERSION", versionParam.Name)
+	assert.True(t, versionParam.ValidateInputFormat, "expected validate_input_format=true to be parsed")
+	assert.Equal(t, `^[0-9]+\.[0-9]+\.[0-9]+$`, versionParam.RegexPattern)
+
+	envParam := task.Schedule.Parameters[1]
+	assert.Equal(t, "ENV", envParam.Name)
+	assert.False(t, envParam.ValidateInputFormat, "expected validate_input_format default false when absent")
+	assert.Equal(t, "", envParam.RegexPattern)
+}
+
+func Test__ListTasks__WithParameterRegexValidation(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	projectID := "758cb945-7495-4e40-a9a1-4b3991c6a8fe"
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`https://org\.semaphoretext\.xyz/api/v1alpha/tasks\?.*project_id=`+projectID),
+		func(req *http.Request) (*http.Response, error) {
+			body := `[
+				{
+					"id": "bb2ba294-d4b3-48bc-90a7-12dd56e9424c",
+					"name": "deploy",
+					"project_id": "758cb945-7495-4e40-a9a1-4b3991c6a8fe",
+					"branch": "main",
+					"pipeline_file": ".semaphore/deploy.yml",
+					"recurring": false,
+					"parameters": [
+						{
+							"name": "TARGET",
+							"required": true,
+							"default_value": "prod",
+							"validate_input_format": true,
+							"regex_pattern": "^(prod|staging|dev)$"
+						}
+					]
+				}
+			]`
+			return httpmock.NewStringResponse(200, body), nil
+		},
+	)
+
+	c := client.NewTasksV1AlphaApi()
+	tasks, err := c.ListTasks(projectID)
+
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 1)
+	assert.Len(t, tasks[0].Parameters, 1)
+
+	param := tasks[0].Parameters[0]
+	assert.Equal(t, "TARGET", param.Name)
+	assert.True(t, param.ValidateInputFormat)
+	assert.Equal(t, "^(prod|staging|dev)$", param.RegexPattern)
 }


### PR DESCRIPTION
Adds regex_pattern and validate_input_format fields to task parameters on both the project and task API models, so the new server-side format validation is preserved end-to-end through the CLI. sem get, sem edit, sem apply, and sem create now round-trip these fields, with tests covering each command.